### PR TITLE
Upgrade Django from 1.10 to 1.11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 ### Development dependencies
 
 # Debug toolbar
-django-debug-toolbar < 1.10  # 1.10 requires Django 1.11
+django-debug-toolbar
 
 # Code linting
 flake8

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Web framework
-Django >= 1.10, < 1.11
+Django >= 1.11, < 2.0
 
 # Database adapter
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 #
 #    pip-compile
 #
-django==1.10.8
+django==1.11.27
 pillow==6.2.1
 psycopg2==2.8.4
+pytz==2019.3              # via django
 reportlab==3.5.23


### PR DESCRIPTION
Builds upon #6, so review and merge that first.

This Django version actually has security support for two more months!

I've tested a bit manually: Creating two new accounts, making a deposit, transferring between the accounts, viewing graphs, creating a new list, and rendering it as PDF all works.