### PR TITLE
Add short_name to transaction form

### DIFF
--- a/itkufs/templates/reports/list_transaction_form.html
+++ b/itkufs/templates/reports/list_transaction_form.html
@@ -28,7 +28,7 @@
 
 <table class="tablelist">
     <tr>
-        <th>{% trans "Accounts" %}</th>
+        <th colspan="2">{% trans "Accounts" %}</th>
         {% for field in form.columns %}
             <th{% if field.errors %} class="error"{% endif %}>{{ field.label }} <br /> {{ field }}</th>
         {% endfor %}
@@ -36,6 +36,7 @@
     {% for account, fields in form.accounts %}
         <tr class="{% cycle "evenrow" "oddrow" %}">
             <td>{{ account.name }}</td>
+            <td>{{ account.short_name }}</td>
             {% for field in fields %}
                 <td{% if field.errors %} class="error"{% endif %}>{{ field }}</td>
             {% endfor %}


### PR DESCRIPTION
Adds account.short_name to the "Create transaction from list"-form, so both the full name and callsign/nickname is listed.