### PR TITLE
Remove inactive accounts from choices in 'Edit list'

### DIFF
--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -99,7 +99,7 @@ class ListForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["extra_accounts"].choices = [
-            (a.id, a.name) for a in group.account_set.all()
+            (a.id, a.name) for a in group.account_set.all() if a.active
         ]
 
     def clean(self):

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -99,7 +99,7 @@ class ListForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["extra_accounts"].choices = [
-            (a.id, a.name) for a in group.account_set.all() if a.active
+            (a.id, a.name) for a in group.account_set.filter(active=True)
         ]
 
     def clean(self):


### PR DESCRIPTION
When editing a list, inactive accounts are shown in the form as "Selected"/"Available". Inactive accounts do not show up on printed lists anyway, so there is no point showing them here.