### PR TITLE
fix: Add date to transaction form

### DIFF
--- a/itkufs/accounting/forms.py
+++ b/itkufs/accounting/forms.py
@@ -37,7 +37,7 @@ class TransactionSettlementForm(ModelForm):
 
     class Meta:
         model = Transaction
-        fields = ("settlement",)
+        fields = ("settlement", "date")
 
 
 class ChangeTransactionForm(forms.Form):

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _, ugettext
+from django.utils.timezone import now
 
 
 class Group(models.Model):
@@ -547,6 +548,7 @@ class Transaction(models.Model):
     )
     date = models.DateField(
         _("date"),
+        default=now,
         help_text=_("May be used for date of the transaction if not today."),
     )
     last_modified = models.DateTimeField(_("Last modified"), auto_now_add=True)

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _, ugettext
-from django.utils.timezone import now
 
 
 class Group(models.Model):
@@ -548,7 +547,7 @@ class Transaction(models.Model):
     )
     date = models.DateField(
         _("date"),
-        default=now,
+        default=datetime.date.today,
         help_text=_("May be used for date of the transaction if not today."),
     )
     last_modified = models.DateTimeField(_("Last modified"), auto_now_add=True)

--- a/itkufs/accounting/tests/test_models.py
+++ b/itkufs/accounting/tests/test_models.py
@@ -557,6 +557,12 @@ class TransactionTestCase(unittest.TestCase):
                 message="Reason for rejecting", user=self.user
             )
 
+    def testDefaultDate(self):
+        """Checks that the default date is the current date"""
+
+        transaction = self.transaction
+        assert transaction.date == datetime.date.today()
+
 
 class LogTestCase(unittest.TestCase):
     def setUp(self):

--- a/itkufs/accounting/views/edit.py
+++ b/itkufs/accounting/views/edit.py
@@ -346,6 +346,7 @@ def new_edit_transaction(request, group, transaction=None, is_admin=False):
     elif transaction.id:
         data = {}
         # Load "fake" post data if we are editing a transaction
+        data["settlement-date"] = transaction.date
         for e in transaction.entry_set.all():
             if e.debit > 0:
                 data["%d-debit" % e.account.id] = e.debit

--- a/itkufs/locale/no/LC_MESSAGES/django.po
+++ b/itkufs/locale/no/LC_MESSAGES/django.po
@@ -852,27 +852,27 @@ msgstr "Avvis"
 #: itkufs/templates/accounting/settlement_details.html:7
 #: itkufs/templates/accounting/transaction_details.html:20
 msgid "Settlement"
-msgstr "oppgjør"
+msgstr "Oppgjør"
 
 #: itkufs/templates/accounting/settlement_details.html:15
 msgid "Settlement ID"
-msgstr "oppgjørs-id"
+msgstr "Oppgjørs-ID"
 
 #: itkufs/templates/accounting/settlement_details.html:19
 #: itkufs/templates/accounting/settlement_list.html:41
 #: itkufs/templates/billing/bill_list.html:13
 msgid "Date"
-msgstr "dato"
+msgstr "Dato"
 
 #: itkufs/templates/accounting/settlement_details.html:23
 #: itkufs/templates/accounting/settlement_list.html:42
 msgid "Comment"
-msgstr "kommentar"
+msgstr "Kommentar"
 
 #: itkufs/templates/accounting/settlement_details.html:27
 #: itkufs/templates/accounting/settlement_list.html:43
 msgid "Closed"
-msgstr "lukket"
+msgstr "Lukket"
 
 #: itkufs/templates/accounting/settlement_details.html:28
 #: itkufs/templates/accounting/settlement_list.html:50

--- a/itkufs/templates/accounting/approve_transactions.html
+++ b/itkufs/templates/accounting/approve_transactions.html
@@ -7,7 +7,6 @@
     - {{ block.super }}
 {% endblock %}
 
-
 {% block breadcrumbs %}
     {{ block.super }}
     &raquo; <a href="{% url "approve-transactions" group.slug %}">
@@ -33,7 +32,6 @@
 {% csrf_token %}
 
 <div id="transactions">
-
 {% if not transaction_list %}
 <p>{% trans "No transactions found." %}</p>
 {% else %}
@@ -43,6 +41,7 @@
 <table class="tablelist">
     <tr>
             <th>{% trans "ID" %}</th>
+            <th>{% trans "Date" %}</th>
             <th>{% trans "Account" %}</th>
             <th>{% trans "Debit" %}</th>
             <th>{% trans "Credit" %}</th>
@@ -54,6 +53,9 @@
     <tr>
         <td rowspan="{{ t.entry_set.all.count }}">
             <a href="{{ t.get_absolute_url }}">{{ t.id }}</a>
+        </td>
+        <td rowspan="{{ t.entry_set.all.count }}">
+            {{ t.date }}
         </td>
         {% for e in t.entry_set.all %}
         <td>

--- a/itkufs/templates/accounting/transaction_details.html
+++ b/itkufs/templates/accounting/transaction_details.html
@@ -32,6 +32,10 @@
         <td class="{{ transaction.css_class }} state">{{ transaction.get_state_display }}</th>
     </tr>
     <tr>
+        <th>{% trans "Date" %}</th>
+        <td>{{ transaction.date }}</th>
+    </tr>
+    <tr>
         <th>{% trans "Last modified" %}</th>
         <td>{{ transaction.last_modified|date }} {{ transaction.last_modified|time }}</th>
     </tr>

--- a/itkufs/templates/accounting/transaction_list_table.html
+++ b/itkufs/templates/accounting/transaction_list_table.html
@@ -4,6 +4,7 @@
 <table class="tablelist">
     <tr>
         <th>{% trans "ID" %}</th>
+        <th>{% trans "Date" %}</th>
         <th>{% trans "Account" %}</th>
         <th>{% trans "Debit" %}</th>
         <th>{% trans "Credit" %}</th>
@@ -16,6 +17,9 @@
                 {% if forloop.first %}
                     <td rowspan="{{ entry_list|length }}">
                         <a href="{{ t.get_absolute_url }}">{{ t.id }}</a>
+                    </td>
+                    <td rowspan="{{ entry_list|length }}">
+                        {{ t.date }}
                     </td>
                 {% else %}
                     <tr>


### PR DESCRIPTION
Adds date field to transaction form, allowing this to be set manually. Defaults to "today", in YYYY-MM-DD format.

![image](https://user-images.githubusercontent.com/42863501/200128299-95f48f29-6ac0-4de6-8b37-eef3093baa88.png)


Resolves #105 (https://github.com/itkinside/ufs/issues/105)