### PR TITLE
Add type hints

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,15 @@
+# Global options
+[mypy]
+
+# Per-module options
+[mypy-django.*]
+# FIXME: Add stubs and disable this?
+ignore_missing_imports = True 
+
+[mypy-reportlab.*]
+# FIXME: Add stubs and disable this?
+ignore_missing_imports = True 
+
+[mypy-debug_toolbar.*]
+# FIXME: Add stubs and disable this?
+ignore_missing_imports = True 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -111,8 +111,9 @@ How to run code linting
 To run code linting, run::
 
     python3 -m flake8
+    mypy .
 
-Ideally, this command should not print a single warning.
+Ideally, these commands should not print a single warning.
 
 ..
     vim: ft=rst tw=74 ai

--- a/itkufs/accounting/management/commands/createuser.py
+++ b/itkufs/accounting/management/commands/createuser.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
             user = self._create_user(options["username"])
             self._create_account(options["group_slug"], user, full_name)
 
-    def _get_full_name(self, username):
+    def _get_full_name(self, username: str):
         try:
             return getpwnam(username)[4].split(",")[0]
         except (IndexError, KeyError):
@@ -79,7 +79,7 @@ class Command(BaseCommand):
             )
             return username
 
-    def _get_confirmation(self, username, full_name):
+    def _get_confirmation(self, username: str, full_name: str):
         question = f"Add {username} ({full_name})? y/N "
         answer = input(question)
         if answer.lower() == "y":
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             self.logger.info('Skipping "%s"', username)
             return False
 
-    def _create_user(self, username):
+    def _create_user(self, username: str):
         user, created = User.objects.get_or_create(
             username=username, email=f"{username}@{settings.MAIL_DOMAIN}"
         )
@@ -98,7 +98,7 @@ class Command(BaseCommand):
             self.logger.info('User "%s" already exists', user)
         return user
 
-    def _create_account(self, group_slug, user, full_name):
+    def _create_account(self, group_slug: str, user: User, full_name: str):
         group = self._get_group(group_slug)
         account, created = Account.objects.get_or_create(
             group=group,
@@ -118,7 +118,7 @@ class Command(BaseCommand):
             )
         return account
 
-    def _get_group(self, group_slug):
+    def _get_group(self, group_slug: str):
         try:
             return Group.objects.get(slug=group_slug)
         except Group.DoesNotExist:

--- a/itkufs/accounting/management/commands/sendmail.py
+++ b/itkufs/accounting/management/commands/sendmail.py
@@ -7,6 +7,9 @@ import sys
 import logging
 from optparse import make_option
 
+# This is needed for type hints in Python versions older than 3.9
+from typing import List as ListType
+
 from django.utils.translation import ugettext_lazy as _, activate
 from django.core.management.base import BaseCommand
 from django.core.mail import EmailMessage, SMTPConnection
@@ -90,7 +93,7 @@ class Command(BaseCommand):
         accounts = group.account_set.filter(owner__isnull=False)
         return accounts.select_related("group", "owner")
 
-    def _build_emails(self, accounts: list[Account]):
+    def _build_emails(self, accounts: ListType[Account]):
         emails = []
 
         for account in accounts:

--- a/itkufs/accounting/management/commands/sendmail.py
+++ b/itkufs/accounting/management/commands/sendmail.py
@@ -146,7 +146,7 @@ class Command(BaseCommand):
             subject, message, FROM_EMAIL, [to_email], headers=headers
         )
 
-    def _print_debug(self, emails: list[str]):
+    def _print_debug(self, emails: ListType[str]):
         for email in emails:
             print("From: %s" % email.from_email)
             print("To: %s" % ";".join(email.to))

--- a/itkufs/accounting/management/commands/sendmail.py
+++ b/itkufs/accounting/management/commands/sendmail.py
@@ -146,7 +146,7 @@ class Command(BaseCommand):
             subject, message, FROM_EMAIL, [to_email], headers=headers
         )
 
-    def _print_debug(self, emails: ListType[str]):
+    def _print_debug(self, emails: ListType[EmailMessage]):
         for email in emails:
             print("From: %s" % email.from_email)
             print("To: %s" % ";".join(email.to))

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -8,6 +8,8 @@ from django.urls import reverse
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _, ugettext
 
+from typing import List as ListType
+
 
 class Group(models.Model):
     name = models.CharField(_("name"), max_length=100)
@@ -94,13 +96,13 @@ class Group(models.Model):
             )
             cash_role.save()
 
-    def get_user_account_set(self):
+    def get_user_account_set(self) -> ListType["Account"]:
         """Returns all user accounts belonging to group"""
         return self.account_set.exclude(group_account=True)
 
     user_account_set = property(get_user_account_set, None, None)
 
-    def get_group_account_set(self):
+    def get_group_account_set(self) -> ListType["Account"]:
         """Returns all non-user accounts belonging to group"""
         return self.account_set.filter(group_account=True)
 
@@ -109,7 +111,7 @@ class Group(models.Model):
     # --- Transaction set methods
     # Please keep in sync with Account's set methods
 
-    def get_transaction_set_with_rejected(self):
+    def get_transaction_set_with_rejected(self) -> ListType["Transaction"]:
         """Returns all transactions connected to group, including rejected"""
         return self.real_transaction_set.exclude(
             state=Transaction.UNDEFINED_STATE
@@ -119,7 +121,7 @@ class Group(models.Model):
         get_transaction_set_with_rejected, None, None
     )
 
-    def get_transaction_set(self):
+    def get_transaction_set(self) -> ListType["Transaction"]:
         """Returns all transactions connected to group, excluding rejected"""
         return self.transaction_set_with_rejected.exclude(
             state=Transaction.REJECTED_STATE
@@ -127,13 +129,13 @@ class Group(models.Model):
 
     transaction_set = property(get_transaction_set, None, None)
 
-    def get_pending_transaction_set(self):
+    def get_pending_transaction_set(self) -> ListType["Transaction"]:
         """Returns all pending transactions connected to group"""
         return self.transaction_set.filter(state=Transaction.PENDING_STATE)
 
     pending_transaction_set = property(get_pending_transaction_set, None, None)
 
-    def get_committed_transaction_set(self):
+    def get_committed_transaction_set(self) -> ListType["Transaction"]:
         """Returns all committed transactions connected to group"""
         return self.transaction_set.filter(state=Transaction.COMMITTED_STATE)
 
@@ -141,7 +143,7 @@ class Group(models.Model):
         get_committed_transaction_set, None, None
     )
 
-    def get_rejected_transaction_set(self):
+    def get_rejected_transaction_set(self) -> ListType["Transaction"]:
         """Returns all rejected transactions connected to group"""
         return self.transaction_set_with_rejected.filter(
             state=Transaction.REJECTED_STATE
@@ -157,7 +159,9 @@ class Group(models.Model):
 
     balance_history_set = property(get_balance_history_set, None, None)
 
-    def get_all_entries(self, from_date: str, to_date: str):
+    def get_all_entries(
+        self, from_date: str, to_date: str
+    ) -> ListType["TransactionEntry"]:
         """
         Returns entries for committed transactions for this group, in the
         range [from_date, to_date] (inclusive).
@@ -313,7 +317,7 @@ class Account(models.Model):
             else:
                 return total_usage
 
-    def last_30_days_usage(self):
+    def last_30_days_usage(self) -> float:
         from_date = datetime.datetime.now() - datetime.timedelta(days=30)
         usage = (
             TransactionEntry.objects.filter(
@@ -324,7 +328,7 @@ class Account(models.Model):
         )
         return usage if usage is not None else 0
 
-    def balance(self):
+    def balance(self) -> float:
         if hasattr(self, "confirmed_balance_sql"):
             return self.confirmed_balance_sql or 0
         else:
@@ -332,7 +336,7 @@ class Account(models.Model):
                 cursor.execute(CONFIRMED_BALANCE_SQL, [self.id])
                 return cursor.fetchone()[0]
 
-    def normal_balance(self):
+    def normal_balance(self) -> float:
         """Returns account balance, but multiplies by -1 if the account is
         of type liability, equity or expense."""
 
@@ -376,7 +380,7 @@ class Account(models.Model):
     # --- Transaction set methods
     # Please keep in sync with Group's set methods
 
-    def get_transaction_set_with_rejected(self):
+    def get_transaction_set_with_rejected(self) -> ListType["Transaction"]:
         """Returns all transactions connected to account, including rejected"""
         return (
             Transaction.objects.filter(entry_set__account=self)
@@ -388,7 +392,7 @@ class Account(models.Model):
         get_transaction_set_with_rejected, None, None
     )
 
-    def get_transaction_set(self):
+    def get_transaction_set(self) -> ListType["Transaction"]:
         """Returns all transactions connected to account, excluding rejected"""
         return self.transaction_set_with_rejected.exclude(
             state=Transaction.REJECTED_STATE
@@ -396,13 +400,13 @@ class Account(models.Model):
 
     transaction_set = property(get_transaction_set, None, None)
 
-    def get_pending_transaction_set(self):
+    def get_pending_transaction_set(self) -> ListType["Transaction"]:
         """Returns all pending transactions connected to account"""
         return self.transaction_set.filter(state=Transaction.PENDING_STATE)
 
     pending_transaction_set = property(get_pending_transaction_set, None, None)
 
-    def get_committed_transaction_set(self):
+    def get_committed_transaction_set(self) -> ListType["Transaction"]:
         """Returns all committed transactions connected to account"""
         return self.transaction_set.filter(state=Transaction.COMMITTED_STATE)
 
@@ -410,7 +414,7 @@ class Account(models.Model):
         get_committed_transaction_set, None, None
     )
 
-    def get_rejected_transaction_set(self):
+    def get_rejected_transaction_set(self) -> ListType["Transaction"]:
         """Returns all rejected transactions connected to account"""
         return self.transaction_set_with_rejected.filter(
             state=Transaction.REJECTED_STATE

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -639,7 +639,7 @@ class Transaction(models.Model):
         self.last_modified = datetime.datetime.now()
         super().save(*args, **kwargs)
 
-    def set_pending(self, user, message=""):
+    def set_pending(self, user: User, message=""):
         if self.id is None:
             self.save()
 
@@ -655,7 +655,7 @@ class Transaction(models.Model):
         else:
             raise InvalidTransaction("Could not set transaction as pending")
 
-    def set_committed(self, user, message=""):
+    def set_committed(self, user: User, message=""):
         if self.is_pending() and not self.is_committed():
             log = TransactionLog(type=self.COMMITTED_STATE, transaction=self)
             log.user = user
@@ -674,7 +674,7 @@ class Transaction(models.Model):
         else:
             raise InvalidTransaction("Could not set transaction as committed")
 
-    def set_rejected(self, user, message=""):
+    def set_rejected(self, user: User, message=""):
         if self.is_pending() and not self.is_committed():
             log = TransactionLog(type=self.REJECTED_STATE, transaction=self)
             log.user = user

--- a/itkufs/accounting/views/edit.py
+++ b/itkufs/accounting/views/edit.py
@@ -1,7 +1,12 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction as db_transaction
-from django.http import HttpResponseForbidden, HttpResponseRedirect, Http404
+from django.http import (
+    HttpRequest,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
+    Http404,
+)
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -10,8 +15,10 @@ from itkufs.common.utils import callsign_sorted as ufs_sorted
 from itkufs.common.decorators import limit_to_owner, limit_to_admin
 from itkufs.accounting.models import (
     Account,
+    Group,
     RoleAccount,
     InvalidTransaction,
+    Settlement,
     Transaction,
     TransactionEntry,
 )
@@ -28,7 +35,12 @@ from itkufs.accounting.forms import (
 
 @login_required
 @limit_to_admin
-def new_edit_settlement(request, group, settlement=None, is_admin=False):
+def new_edit_settlement(
+    request: HttpRequest,
+    group: Group,
+    settlement: Settlement = None,
+    is_admin=False,
+):
     """Create new and edit existing settlements"""
 
     if settlement is not None and not settlement.is_editable():
@@ -73,10 +85,10 @@ def new_edit_settlement(request, group, settlement=None, is_admin=False):
 @limit_to_owner
 @db_transaction.atomic
 def transfer(
-    request,
-    group,
-    account=None,
-    transfer_type=None,
+    request: HttpRequest,
+    group: Group,
+    account: Transaction = None,
+    transfer_type: str = None,
     is_admin=False,
     is_owner=False,
 ):
@@ -172,7 +184,9 @@ def transfer(
 
 @login_required
 @limit_to_admin
-def approve_transactions(request, group, page="1", is_admin=False):
+def approve_transactions(
+    request: HttpRequest, group: Group, page="1", is_admin=False
+):
     """Approve transactions from members and other groups"""
 
     transactions = []
@@ -248,7 +262,12 @@ def approve_transactions(request, group, page="1", is_admin=False):
 
 @login_required
 @limit_to_owner
-def reject_transactions(request, group, transaction=None, is_admin=False):
+def reject_transactions(
+    request: HttpRequest,
+    group: Group,
+    transaction: Transaction = None,
+    is_admin=False,
+):
     """Reject transactions from members and other groups"""
 
     if request.method == "POST":
@@ -325,7 +344,12 @@ def reject_transactions(request, group, transaction=None, is_admin=False):
 @login_required
 @limit_to_admin
 @db_transaction.atomic
-def new_edit_transaction(request, group, transaction=None, is_admin=False):
+def new_edit_transaction(
+    request: HttpRequest,
+    group: Group,
+    transaction: Transaction = None,
+    is_admin=False,
+):
     """Admin view for creating transactions"""
 
     savepoint_id = db_transaction.savepoint()

--- a/itkufs/accounting/views/edit.py
+++ b/itkufs/accounting/views/edit.py
@@ -89,7 +89,7 @@ def new_edit_settlement(
 def transfer(
     request: HttpRequest,
     group: Group,
-    account: Optional[Account] = None,
+    account: Account,
     transfer_type: Optional[str] = None,
     is_admin=False,
     is_owner=False,

--- a/itkufs/accounting/views/edit.py
+++ b/itkufs/accounting/views/edit.py
@@ -38,7 +38,7 @@ from itkufs.accounting.forms import (
 def new_edit_settlement(
     request: HttpRequest,
     group: Group,
-    settlement: Settlement = None,
+    settlement: Optional[Settlement] = None,
     is_admin=False,
 ):
     """Create new and edit existing settlements"""
@@ -87,8 +87,8 @@ def new_edit_settlement(
 def transfer(
     request: HttpRequest,
     group: Group,
-    account: Transaction = None,
-    transfer_type: str = None,
+    account: Optional[Account] = None,
+    transfer_type: Optional[str] = None,
     is_admin=False,
     is_owner=False,
 ):
@@ -265,7 +265,7 @@ def approve_transactions(
 def reject_transactions(
     request: HttpRequest,
     group: Group,
-    transaction: Transaction = None,
+    transaction: Optional[Transaction] = None,
     is_admin=False,
 ):
     """Reject transactions from members and other groups"""
@@ -347,7 +347,7 @@ def reject_transactions(
 def new_edit_transaction(
     request: HttpRequest,
     group: Group,
-    transaction: Transaction = None,
+    transaction: Optional[Transaction] = None,
     is_admin=False,
 ):
     """Admin view for creating transactions"""

--- a/itkufs/accounting/views/edit.py
+++ b/itkufs/accounting/views/edit.py
@@ -32,6 +32,8 @@ from itkufs.accounting.forms import (
     TransferForm,
 )
 
+from typing import Optional
+
 
 @login_required
 @limit_to_admin

--- a/itkufs/billing/pdf.py
+++ b/itkufs/billing/pdf.py
@@ -19,6 +19,8 @@ from django.utils.html import escape
 from django.template.defaultfilters import slugify
 
 from itkufs.reports.pdf import ALTERNATE_COLORS, BORDER_COLOR
+from itkufs.accounting.models import Group
+from itkufs.billing.models import Bill
 
 styles = getSampleStyleSheet()
 styles["Normal"].spaceAfter = 5
@@ -39,7 +41,7 @@ table_style = TableStyle(
 )
 
 
-def pdf(group, bill):
+def pdf(group: Group, bill: Bill):
     """PDF version of bill"""
 
     width, height = A4

--- a/itkufs/billing/views.py
+++ b/itkufs/billing/views.py
@@ -16,11 +16,16 @@ from itkufs.billing.forms import (
     CreateTransactionForm,
 )
 
+from typing import Optional
+
 
 @login_required
 @limit_to_admin
 def bill_new_edit(
-    request: HttpRequest, group: Group, bill: Optional[Bill] = None, is_admin=False
+    request: HttpRequest,
+    group: Group,
+    bill: Optional[Bill] = None,
+    is_admin=False,
 ):
     if bill is None:
         bill = Bill()

--- a/itkufs/billing/views.py
+++ b/itkufs/billing/views.py
@@ -20,7 +20,7 @@ from itkufs.billing.forms import (
 @login_required
 @limit_to_admin
 def bill_new_edit(
-    request: HttpRequest, group: Group, bill: Bill = None, is_admin=False
+    request: HttpRequest, group: Group, bill: Optional[Bill] = None, is_admin=False
 ):
     if bill is None:
         bill = Bill()

--- a/itkufs/billing/views.py
+++ b/itkufs/billing/views.py
@@ -1,12 +1,12 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpRequest
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from itkufs.common.decorators import limit_to_admin
-from itkufs.accounting.models import Account, Transaction
+from itkufs.accounting.models import Account, Transaction, Group
 from itkufs.billing.models import Bill
 from itkufs.billing.pdf import pdf
 from itkufs.billing.forms import (
@@ -19,7 +19,9 @@ from itkufs.billing.forms import (
 
 @login_required
 @limit_to_admin
-def bill_new_edit(request, group, bill=None, is_admin=False):
+def bill_new_edit(
+    request: HttpRequest, group: Group, bill: Bill = None, is_admin=False
+):
     if bill is None:
         bill = Bill()
         LineFormSet = NewBillingLineFormSet
@@ -71,7 +73,9 @@ def bill_new_edit(request, group, bill=None, is_admin=False):
 
 @login_required
 @limit_to_admin
-def bill_create_transaction(request, group, bill, is_admin=False):
+def bill_create_transaction(
+    request: HttpRequest, group: Group, bill: Bill, is_admin=False
+):
     if not bill.is_editable():
         messages.info(
             request, _("This bill is already linked to a transaction.")
@@ -129,7 +133,7 @@ def bill_create_transaction(request, group, bill, is_admin=False):
 
 @login_required
 @limit_to_admin
-def bill_list(request, group, is_admin=False):
+def bill_list(request: HttpRequest, group: Group, is_admin=False):
     return render(
         request,
         "billing/bill_list.html",
@@ -139,7 +143,9 @@ def bill_list(request, group, is_admin=False):
 
 @login_required
 @limit_to_admin
-def bill_details(request, group, bill, is_admin=False):
+def bill_details(
+    request: HttpRequest, group: Group, bill: Bill, is_admin=False
+):
     return render(
         request,
         "billing/bill_details.html",
@@ -149,7 +155,7 @@ def bill_details(request, group, bill, is_admin=False):
 
 @login_required
 @limit_to_admin
-def bill_delete(request, group, bill, is_admin=False):
+def bill_delete(request: HttpRequest, group: Group, bill: Bill, is_admin=False):
     if request.method == "POST":
         messages.info(request, _("Bill #%d deleted.") % bill.id)
         bill.delete()
@@ -165,5 +171,5 @@ def bill_delete(request, group, bill, is_admin=False):
 
 @login_required
 @limit_to_admin
-def bill_pdf(request, group, bill, is_admin=False):
+def bill_pdf(request: HttpRequest, group: Group, bill: Bill, is_admin=False):
     return pdf(group, bill)

--- a/itkufs/common/context_processors.py
+++ b/itkufs/common/context_processors.py
@@ -1,7 +1,8 @@
 from django.conf import settings
+from django.http import HttpRequest
 
 
-def debug(request):
+def debug(request: HttpRequest):
     """
     Returns context variables helpful for debugging
 

--- a/itkufs/common/utils.py
+++ b/itkufs/common/utils.py
@@ -1,5 +1,7 @@
 import re
 
+from itkufs.accounting.models import Account
+
 CALLSIGN_RE = re.compile(r"^[A-Z]+[0-9][A-Z0-9]*[A-Z]$")
 
 
@@ -21,7 +23,7 @@ def verify_account_number(num):
     )
 
 
-def callsign_sorted(accounts):
+def callsign_sorted(accounts: list[Account]):
     """
     ARK friendly sort method that should sort in the following order:
 
@@ -33,7 +35,7 @@ def callsign_sorted(accounts):
     return sorted(accounts, key=callsign_key)
 
 
-def callsign_key(account):
+def callsign_key(account: Account):
     is_callsign = account.short_name and CALLSIGN_RE.match(account.short_name)
     is_la = is_callsign and account.short_name.startswith("LA")
     is_lb = is_callsign and account.short_name.startswith("LB")

--- a/itkufs/common/utils.py
+++ b/itkufs/common/utils.py
@@ -1,5 +1,8 @@
 import re
 
+# This is needed for type hints in Python versions older than 3.9
+from typing import List as ListType
+
 from itkufs.accounting.models import Account
 
 CALLSIGN_RE = re.compile(r"^[A-Z]+[0-9][A-Z0-9]*[A-Z]$")
@@ -23,7 +26,7 @@ def verify_account_number(num):
     )
 
 
-def callsign_sorted(accounts: list[Account]):
+def callsign_sorted(accounts: ListType[Account]):
     """
     ARK friendly sort method that should sort in the following order:
 

--- a/itkufs/common/views/__init__.py
+++ b/itkufs/common/views/__init__.py
@@ -1,6 +1,11 @@
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
-from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
+from django.http import (
+    Http404,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
+    HttpRequest,
+)
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -8,7 +13,7 @@ from django.utils.translation import ugettext as _
 from itkufs.accounting.models import Group, Account
 
 
-def login_user(request):
+def login_user(request: HttpRequest):
     """Login user"""
 
     if not request.user.is_authenticated:
@@ -44,7 +49,7 @@ def login_user(request):
 
 
 @login_required
-def switch_group(request, is_admin=False):
+def switch_group(request: HttpRequest, is_admin=False):
     """Switch to account summary for the selected account"""
 
     if request.method != "POST":
@@ -62,7 +67,7 @@ def switch_group(request, is_admin=False):
 
 
 @login_required
-def static_page(request, template, is_admin=False):
+def static_page(request: HttpRequest, template, is_admin=False):
     return render(
         request,
         template,

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -4,7 +4,7 @@ import csv
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import render
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 
 from itkufs.common.decorators import (
     limit_to_group,
@@ -21,7 +21,7 @@ from itkufs.accounting.models import (
 
 @login_required
 @limit_to_admin
-def export_transactions(request, group: Group, is_admin=False):
+def export_transactions(request: HttpRequest, group: Group, is_admin=False):
 
     form = ExportTransactionsForm(data=request.GET)
     filename = f"{group.slug}-transactions.csv"
@@ -78,7 +78,7 @@ def export_transactions(request, group: Group, is_admin=False):
 
 @login_required
 @limit_to_group
-def group_summary(request, group, is_admin=False):
+def group_summary(request: HttpRequest, group: Group, is_admin=False):
     """Show group summary"""
 
     return render(
@@ -94,7 +94,13 @@ def group_summary(request, group, is_admin=False):
 
 @login_required
 @limit_to_owner
-def account_summary(request, group, account, is_admin=False, is_owner=False):
+def account_summary(
+    request: HttpRequest,
+    group: Group,
+    account: Account,
+    is_admin=False,
+    is_owner=False,
+):
     """Show account summary"""
 
     if is_owner:
@@ -134,7 +140,7 @@ def account_summary(request, group, account, is_admin=False, is_owner=False):
 
 @login_required
 @limit_to_group
-def group_balance_graph(request, group, is_admin=False):
+def group_balance_graph(request: HttpRequest, group: Group, is_admin=False):
     accounts = (
         Account.objects.all()
         .filter(group_id=group.id, active=True, group_account=False)

--- a/itkufs/common/views/edit.py
+++ b/itkufs/common/views/edit.py
@@ -2,19 +2,19 @@ import os
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpRequest
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from itkufs.common.decorators import limit_to_admin
 from itkufs.common.forms import GroupForm, AccountForm, RoleAccountForm
-from itkufs.accounting.models import RoleAccount
+from itkufs.accounting.models import RoleAccount, Group, Account
 
 
 @login_required
 @limit_to_admin
-def edit_group(request, group, is_admin=False):
+def edit_group(request: HttpRequest, group: Group, is_admin=False):
     """Edit group properties"""
 
     if request.method == "POST":
@@ -58,7 +58,11 @@ def edit_group(request, group, is_admin=False):
 
 @login_required
 def activate_account(
-    request, group, account=None, is_admin=False, is_owner=False
+    request: HttpRequest,
+    group: Group,
+    account: Account = None,
+    is_admin=False,
+    is_owner=False,
 ):
     """Create account or edit account properties"""
 
@@ -77,7 +81,11 @@ def activate_account(
 @login_required
 @limit_to_admin
 def new_edit_account(
-    request, group, account=None, is_admin=False, is_owner=False
+    request: HttpRequest,
+    group: Group,
+    account: Account = None,
+    is_admin=False,
+    is_owner=False,
 ):
     """Create account or edit account properties"""
 
@@ -119,7 +127,7 @@ def new_edit_account(
 
 @login_required
 @limit_to_admin
-def assign_role_accounts(request, group, is_admin=False):
+def assign_role_accounts(request: HttpRequest, group: Group, is_admin=False):
     """Assign role accounts to group"""
 
     if request.method == "POST":

--- a/itkufs/common/views/edit.py
+++ b/itkufs/common/views/edit.py
@@ -60,7 +60,7 @@ def edit_group(request: HttpRequest, group: Group, is_admin=False):
 def activate_account(
     request: HttpRequest,
     group: Group,
-    account: Account = None,
+    account: Optional[Account] = None,
     is_admin=False,
     is_owner=False,
 ):
@@ -83,7 +83,7 @@ def activate_account(
 def new_edit_account(
     request: HttpRequest,
     group: Group,
-    account: Account = None,
+    account: Optional[Account] = None,
     is_admin=False,
     is_owner=False,
 ):

--- a/itkufs/common/views/edit.py
+++ b/itkufs/common/views/edit.py
@@ -11,6 +11,8 @@ from itkufs.common.decorators import limit_to_admin
 from itkufs.common.forms import GroupForm, AccountForm, RoleAccountForm
 from itkufs.accounting.models import RoleAccount, Group, Account
 
+from typing import Optional
+
 
 @login_required
 @limit_to_admin

--- a/itkufs/common/views/edit.py
+++ b/itkufs/common/views/edit.py
@@ -62,7 +62,7 @@ def edit_group(request: HttpRequest, group: Group, is_admin=False):
 def activate_account(
     request: HttpRequest,
     group: Group,
-    account: Optional[Account] = None,
+    account: Account,
     is_admin=False,
     is_owner=False,
 ):

--- a/itkufs/locale/no/LC_MESSAGES/django.po
+++ b/itkufs/locale/no/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-24 00:30+0100\n"
+"POT-Creation-Date: 2022-11-25 18:16+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Stein Magnus Jodal <jodal@samfundet.no>\n"
 "Language-Team: The uFS Developers <itk-ufs@samfundet.no>\n"
@@ -27,7 +27,7 @@ msgstr "Avanserte valg"
 msgid "Details"
 msgstr "Detaljer"
 
-#: itkufs/accounting/forms.py:72 itkufs/billing/pdf.py:116
+#: itkufs/accounting/forms.py:72 itkufs/billing/pdf.py:118
 #: itkufs/templates/billing/bill_details.html:62
 #: itkufs/templates/billing/bill_form.html:16
 msgid "Amount"
@@ -365,48 +365,48 @@ msgstr ""
 "Transaksjonen kan kun sees av gruppeadministatorer eller en part i "
 "transaksjonen."
 
-#: itkufs/accounting/views/edit.py:36
+#: itkufs/accounting/views/edit.py:48
 msgid "Settlement is closed and cannot be edited."
 msgstr "Oppgjøret er avsluttet og kan ikke redigeres."
 
-#: itkufs/accounting/views/edit.py:91
+#: itkufs/accounting/views/edit.py:103
 msgid "Transfer from account"
 msgstr "Overføring fra konto"
 
-#: itkufs/accounting/views/edit.py:94
+#: itkufs/accounting/views/edit.py:106
 msgid "Deposit to account"
 msgstr "Innskudd til konto"
 
-#: itkufs/accounting/views/edit.py:97
+#: itkufs/accounting/views/edit.py:109
 msgid "Withdrawal from account"
 msgstr "Uttak fra konto"
 
-#: itkufs/accounting/views/edit.py:100 itkufs/accounting/views/edit.py:150
+#: itkufs/accounting/views/edit.py:112 itkufs/accounting/views/edit.py:162
 #: itkufs/common/decorators.py:57
 msgid "Forbidden if not group admin."
 msgstr "Bare gruppeadministratiren kan gjøre dette."
 
-#: itkufs/accounting/views/edit.py:144
+#: itkufs/accounting/views/edit.py:156
 msgid "Your transaction has been added, but your group admin has to commit it."
 msgstr ""
 "Transaksjonen er opprettet, men administrator for gruppen má godkjenne den."
 
-#: itkufs/accounting/views/edit.py:152
+#: itkufs/accounting/views/edit.py:164
 #, python-format
 msgid "Added transaction: %s"
 msgstr "La til transaksjon: %s"
 
-#: itkufs/accounting/views/edit.py:234
+#: itkufs/accounting/views/edit.py:248
 #: itkufs/templates/accounting/approve_transactions.html:28
 msgid "No pending transactions found."
 msgstr "Ingen ventende transaksjoner funnet."
 
-#: itkufs/accounting/views/edit.py:336
+#: itkufs/accounting/views/edit.py:360
 #, python-format
 msgid "Transaction %d can't be changed."
 msgstr "Transaksjon %d kan ikke endres"
 
-#: itkufs/accounting/views/edit.py:418
+#: itkufs/accounting/views/edit.py:442
 msgid "Your transaction has been added."
 msgstr "Transaksjonen er opprettet."
 
@@ -434,20 +434,20 @@ msgstr "beskrivelse"
 msgid "amount"
 msgstr "Beløp"
 
-#: itkufs/billing/pdf.py:54
+#: itkufs/billing/pdf.py:56
 msgid "bill"
 msgstr "regning"
 
-#: itkufs/billing/pdf.py:79
+#: itkufs/billing/pdf.py:81
 #, python-format
 msgid "Bill #%d"
 msgstr "Regning #%d"
 
-#: itkufs/billing/pdf.py:85
+#: itkufs/billing/pdf.py:87
 msgid "%Y-%m-%d %H:%M"
 msgstr ""
 
-#: itkufs/billing/pdf.py:116 itkufs/templates/billing/bill_delete.html:34
+#: itkufs/billing/pdf.py:118 itkufs/templates/billing/bill_delete.html:34
 #: itkufs/templates/billing/bill_details.html:33
 #: itkufs/templates/billing/bill_details.html:61
 #: itkufs/templates/billing/bill_form.html:15
@@ -455,20 +455,20 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: itkufs/billing/views.py:30
+#: itkufs/billing/views.py:32
 msgid "This bill can no longer be edited."
 msgstr "Denne regningen kan ikke lenger redigeres."
 
-#: itkufs/billing/views.py:77
+#: itkufs/billing/views.py:81
 msgid "This bill is already linked to a transaction."
 msgstr "Denne regningen er alt knyttet til en transaksjon."
 
-#: itkufs/billing/views.py:110
+#: itkufs/billing/views.py:114
 #, python-format
 msgid "Bill #%(id)s: %(description)s"
 msgstr "Regning #%(id)s: %(description)s"
 
-#: itkufs/billing/views.py:154
+#: itkufs/billing/views.py:160
 #, python-format
 msgid "Bill #%d deleted."
 msgstr "Regning #%d ble slettet."
@@ -517,7 +517,7 @@ msgstr "Vennligst oppgi en dato"
 msgid "To date"
 msgstr "Til dato"
 
-#: itkufs/common/views/__init__.py:19
+#: itkufs/common/views/__init__.py:24
 msgid "Login failed"
 msgstr "Innlogging feilet"
 
@@ -525,15 +525,15 @@ msgstr "Innlogging feilet"
 msgid "Group successfully updated."
 msgstr "Gruppen er oppdatert."
 
-#: itkufs/common/views/edit.py:70
+#: itkufs/common/views/edit.py:74
 msgid "Account successfully activated."
 msgstr "Kontoen er ble aktivert."
 
-#: itkufs/common/views/edit.py:93
+#: itkufs/common/views/edit.py:101
 msgid "Account successfully updated."
 msgstr "Kontoen er oppdatert."
 
-#: itkufs/common/views/edit.py:96
+#: itkufs/common/views/edit.py:104
 msgid "Account successfully created."
 msgstr "Kontoen er opprettet."
 
@@ -663,34 +663,34 @@ msgstr "listeelement"
 msgid "list items"
 msgstr "listeelementer"
 
-#: itkufs/reports/pdf.py:89
+#: itkufs/reports/pdf.py:92
 msgid "Printed"
 msgstr "Skrevet ut"
 
-#: itkufs/reports/pdf.py:89
+#: itkufs/reports/pdf.py:92
 msgid "by"
 msgstr "av"
 
-#: itkufs/reports/pdf.py:106
+#: itkufs/reports/pdf.py:109
 msgid "Blacklisted accounts are marked with: "
 msgstr "Svartelistede kontoer er merket med: "
 
-#: itkufs/reports/pdf.py:115
+#: itkufs/reports/pdf.py:118
 msgid "Sorry, this list is empty."
 msgstr "Listen er tom"
 
-#: itkufs/reports/pdf.py:129
+#: itkufs/reports/pdf.py:132
 msgid "Sorry, this list isn't set up correctly, please add some columns."
 msgstr "Beklager, listen er ikke satt opp rikig, legg til noen koloner først."
 
-#: itkufs/reports/pdf.py:145 itkufs/templates/common/account_summary.html:11
+#: itkufs/reports/pdf.py:148 itkufs/templates/common/account_summary.html:11
 #: itkufs/templates/common/account_summary.html:62
 #: itkufs/templates/common/group_summary.html:11
 #: itkufs/templates/reports/list_form.html:56
 msgid "Name"
 msgstr "Navn"
 
-#: itkufs/reports/pdf.py:157
+#: itkufs/reports/pdf.py:160
 #: itkufs/templates/accounting/transaction_form.html:69
 #: itkufs/templates/common/account_summary.html:37
 #: itkufs/templates/common/group_balance_graph.html:7
@@ -699,24 +699,24 @@ msgstr "Navn"
 msgid "Balance"
 msgstr "Balanse"
 
-#: itkufs/reports/views.py:171
+#: itkufs/reports/views.py:177
 msgid "List deleted."
 msgstr "Listen ble slettet."
 
-#: itkufs/reports/views.py:202
+#: itkufs/reports/views.py:210
 #, python-format
 msgid "Created from list: %s"
 msgstr "Laget fra liste: %s"
 
-#: itkufs/reports/views.py:257
+#: itkufs/reports/views.py:265
 msgid "Positive member accounts"
 msgstr "Positive medlemskontoer"
 
-#: itkufs/reports/views.py:258
+#: itkufs/reports/views.py:266
 msgid "Negative member accounts"
 msgstr "Negative medlemskontoer"
 
-#: itkufs/reports/views.py:273
+#: itkufs/reports/views.py:281
 msgid "Current year's net income"
 msgstr "Nettoinntekt inneværende år"
 

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -119,7 +119,7 @@ class ListForm(forms.ModelForm):
             )
         return self.cleaned_data
 
-    def save(self, group: Group = None, **kwargs):
+    def save(self, group: Optional[Group] = None, **kwargs):
         original_commit = kwargs.pop("commit", True)
 
         kwargs["commit"] = False

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -6,6 +6,8 @@ from django.template.defaultfilters import slugify
 from itkufs.reports.models import List, ListColumn
 from itkufs.accounting.models import Account, TransactionEntry, Group
 
+from typing import Optional
+
 
 class ListTransactionForm(forms.Form):
     def __init__(self, list_, *args, **kwargs):

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.defaultfilters import slugify
 
 from itkufs.reports.models import List, ListColumn
-from itkufs.accounting.models import Account, TransactionEntry
+from itkufs.accounting.models import Account, TransactionEntry, Group
 
 
 class ListTransactionForm(forms.Form):
@@ -119,7 +119,7 @@ class ListForm(forms.ModelForm):
             )
         return self.cleaned_data
 
-    def save(self, group=None, **kwargs):
+    def save(self, group: Group = None, **kwargs):
         original_commit = kwargs.pop("commit", True)
 
         kwargs["commit"] = False

--- a/itkufs/reports/pdf.py
+++ b/itkufs/reports/pdf.py
@@ -23,7 +23,9 @@ FAINT_COLOR = HexColor("#BABDB6")
 ALTERNATE_COLORS = [HexColor("#FFFFFF"), HexColor("#F5F5F5")]
 
 
-def pdf(group: Group, username: str, list: List, show_header=True, show_footer=True):
+def pdf(
+    group: Group, username: str, list: List, show_header=True, show_footer=True
+):
     """PDF version of list"""
 
     content = BytesIO()

--- a/itkufs/reports/pdf.py
+++ b/itkufs/reports/pdf.py
@@ -10,6 +10,9 @@ from reportlab.lib.pagesizes import A4
 
 from django.utils.translation import ugettext as _
 
+from itkufs.accounting.models import Group
+from itkufs.reports.models import List
+
 
 BORDER_COLOR = HexColor("#555753")
 BLACKLISTED_COLOR = HexColor("#000000")
@@ -20,7 +23,7 @@ FAINT_COLOR = HexColor("#BABDB6")
 ALTERNATE_COLORS = [HexColor("#FFFFFF"), HexColor("#F5F5F5")]
 
 
-def pdf(group, username, list, show_header=True, show_footer=True):
+def pdf(group: Group, username: str, list: List, show_header=True, show_footer=True):
     """PDF version of list"""
 
     content = BytesIO()

--- a/itkufs/reports/views.py
+++ b/itkufs/reports/views.py
@@ -5,14 +5,14 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction as db_transaction
 from django.forms.models import inlineformset_factory
-from django.http import Http404, HttpResponseRedirect, HttpResponse
+from django.http import Http404, HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import render
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from itkufs.common.decorators import limit_to_group, limit_to_admin
-from itkufs.accounting.models import Account, Transaction
+from itkufs.accounting.models import Account, Transaction, Group
 from itkufs.reports.models import List, ListColumn
 from itkufs.reports.forms import ColumnForm, ListForm, ListTransactionForm
 from itkufs.reports.pdf import pdf
@@ -20,7 +20,7 @@ from itkufs.reports.pdf import pdf
 _list = list
 
 
-def public_lists(request):
+def public_lists(request: HttpRequest):
     lists = (
         List.objects.filter(public=True)
         .select_related("group")
@@ -36,7 +36,7 @@ def public_lists(request):
 
 @login_required
 @limit_to_group
-def view_list(request, group, list, is_admin=False):
+def view_list(request: HttpRequest, group: Group, list: List, is_admin=False):
     content = pdf(group, request.user.username, list)
 
     filename = "{}-{}-{}".format(date.today(), group, list)
@@ -51,7 +51,9 @@ def view_list(request, group, list, is_admin=False):
 
 @login_required
 @limit_to_group
-def view_list_preview(request, group, list, is_admin=False):
+def view_list_preview(
+    request: HttpRequest, group: Group, list: List, is_admin=False
+):
     content = pdf(
         group, request.user.username, list, show_header=True, show_footer=True
     )
@@ -83,7 +85,9 @@ def view_list_preview(request, group, list, is_admin=False):
     return HttpResponse(stdout, content_type="image/png")
 
 
-def view_public_list(request, group, list, is_admin=False):
+def view_public_list(
+    request: HttpRequest, group: Group, list: List, is_admin=False
+):
     if not list.public:
         raise Http404
 
@@ -102,7 +106,9 @@ def view_public_list(request, group, list, is_admin=False):
 @login_required
 @limit_to_admin
 @db_transaction.atomic
-def new_edit_list(request, group, list=None, is_admin=False):
+def new_edit_list(
+    request: HttpRequest, group: Group, list: List = None, is_admin=False
+):
     """Create new or edit existing list"""
 
     if request.method == "POST":
@@ -162,7 +168,7 @@ def new_edit_list(request, group, list=None, is_admin=False):
 @login_required
 @limit_to_admin
 @db_transaction.atomic
-def delete_list(request, group, list, is_admin=False):
+def delete_list(request: HttpRequest, group: Group, list: List, is_admin=False):
     """Delete list"""
 
     if request.method == "POST":
@@ -184,7 +190,9 @@ def delete_list(request, group, list, is_admin=False):
 @login_required
 @limit_to_admin
 @db_transaction.atomic
-def transaction_from_list(request, group, list, is_admin=False):
+def transaction_from_list(
+    request: HttpRequest, group: Group, list: List, is_admin=False
+):
     """Enter list"""
 
     form = ListTransactionForm(list, request.POST or None)
@@ -218,7 +226,7 @@ def transaction_from_list(request, group, list, is_admin=False):
 
 @login_required
 @limit_to_group
-def balance(request, group, is_admin=False):
+def balance(request: HttpRequest, group: Group, is_admin=False):
     """Show balance sheet for the group"""
 
     # Balance sheet data struct
@@ -289,7 +297,7 @@ def balance(request, group, is_admin=False):
 
 @login_required
 @limit_to_group
-def income(request, group, is_admin=False):
+def income(request: HttpRequest, group: Group, is_admin=False):
     """Show income statement for group"""
 
     # Balance sheet data struct

--- a/itkufs/reports/views.py
+++ b/itkufs/reports/views.py
@@ -17,6 +17,8 @@ from itkufs.reports.models import List, ListColumn
 from itkufs.reports.forms import ColumnForm, ListForm, ListTransactionForm
 from itkufs.reports.pdf import pdf
 
+from typing import Optional
+
 _list = list
 
 
@@ -107,7 +109,10 @@ def view_public_list(
 @limit_to_admin
 @db_transaction.atomic
 def new_edit_list(
-    request: HttpRequest, group: Group, list: List = None, is_admin=False
+    request: HttpRequest,
+    group: Group,
+    list: Optional[List] = None,
+    is_admin=False,
 ):
     """Create new or edit existing list"""
 

--- a/itkufs/templates/reports/balance.html
+++ b/itkufs/templates/reports/balance.html
@@ -44,7 +44,7 @@
     <tr>
         <td><em>{% trans "Total assets" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.as_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.as|floatformat:2 }}</em>
         </td>
     </tr>
 </table>
@@ -80,7 +80,7 @@
     <tr>
         <td><em>&nbsp;&nbsp;{% trans "Total liabilities" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.li_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.li|floatformat:2 }}</em>
         </td>
     </tr>
 
@@ -108,14 +108,14 @@
     <tr>
         <td><em>&nbsp;&nbsp;{% trans "Total equities (Net worth)" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.eq_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.eq|floatformat:2 }}</em>
         </td>
     </tr>
 
     <tr>
         <td><em>{% trans "Total liabilities and equities" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.li_eq_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.li_eq|floatformat:2 }}</em>
         </td>
     </tr>
 </table>

--- a/itkufs/templates/reports/income.html
+++ b/itkufs/templates/reports/income.html
@@ -44,7 +44,7 @@
     <tr>
         <td><em>{% trans "Total revenues and gains" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.in_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.in|floatformat:2 }}</em>
         </td>
     </tr>
 </table>
@@ -68,7 +68,7 @@
     <tr>
         <td><em>{% trans "Total expenses and losses" %}</em></td>
         <td class="align_right">
-            <em>{{ accounts.ex_sum|floatformat:2 }}</em>
+            <em>{{ account_sums.ex|floatformat:2 }}</em>
         </td>
     </tr>
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ black
 
 # Code linting
 flake8
+mypy
 
 # Test runner
 pytest


### PR DESCRIPTION
Adds type hints to function parameters where the type could be easily inferred. Adding these should make further development easier.

Uses `from typing import List` to type collections, as a workaround to support Python versions below 3.9. 