### PR TITLE
fix: Show only active accounts when assigning role accounts

### DIFF
--- a/itkufs/common/forms.py
+++ b/itkufs/common/forms.py
@@ -184,9 +184,9 @@ class RoleAccountForm(Form):
                     ).account.id
                 except RoleAccount.DoesNotExist:
                     intial = ""
-
+                # Populate the form options with active group accounts
                 self.fields[type] = RoleAccountModelChoiceField(
-                    group.group_account_set, initial=intial
+                    group.group_account_set.filter(active=True), initial=intial
                 )
         else:
             raise Exception("Please supply a group kwarg for RoleAccountForm")


### PR DESCRIPTION
This hides inactive accounts from the dropdown lists in `/assign-role-accounts/`. Inactive accounts are probably not relevant here, and quite noisy.