### PR TITLE
Fix black issues

### DIFF
--- a/itkufs/accounting/migrations/0001_initial.py
+++ b/itkufs/accounting/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 
 class Migration(migrations.Migration):
-
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]
 
     operations = [

--- a/itkufs/accounting/migrations/0002_django_upgrade.py
+++ b/itkufs/accounting/migrations/0002_django_upgrade.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("accounting", "0001_initial")]
 
     operations = [

--- a/itkufs/accounting/migrations/0003_python3.py
+++ b/itkufs/accounting/migrations/0003_python3.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("accounting", "0002_django_upgrade"),
     ]

--- a/itkufs/accounting/migrations/0004_auto_20221123_1607.py
+++ b/itkufs/accounting/migrations/0004_auto_20221123_1607.py
@@ -7,15 +7,18 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('accounting', '0003_python3'),
+        ("accounting", "0003_python3"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='transaction',
-            name='date',
-            field=models.DateField(default=datetime.date.today, help_text='May be used for date of the transaction if not today.', verbose_name='date'),
+            model_name="transaction",
+            name="date",
+            field=models.DateField(
+                default=datetime.date.today,
+                help_text="May be used for date of the transaction if not today.",
+                verbose_name="date",
+            ),
         ),
     ]

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -68,7 +68,6 @@ class Group(models.Model):
 
         # Create default accounts
         if not self.account_set.count():
-
             # TODO change this into a magic loop?
             bank = Account(
                 name=ugettext("Bank"),
@@ -843,7 +842,6 @@ class TransactionEntry(models.Model):
             and old_balance > self.account.group.block_limit
             and new_balance < self.account.group.block_limit
         ):
-
             subject = "Svartelistet i µFS"
             msg = (
                 f"Dette er en automatisk melding om at du har blitt "

--- a/itkufs/billing/migrations/0001_initial.py
+++ b/itkufs/billing/migrations/0001_initial.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("accounting", "0001_initial")]
 
     operations = [

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -22,7 +22,6 @@ from itkufs.accounting.models import (
 @login_required
 @limit_to_admin
 def export_transactions(request: HttpRequest, group: Group, is_admin=False):
-
     form = ExportTransactionsForm(data=request.GET)
     filename = f"{group.slug}-transactions.csv"
 

--- a/itkufs/common/widgets.py
+++ b/itkufs/common/widgets.py
@@ -9,7 +9,6 @@ class GroupedSelect(forms.Select):
     """From http://www.djangosnippets.org/snippets/200/"""
 
     def render(self, name, value, attrs=None, choices=()):
-
         if value is None:
             value = ""
         final_attrs = self.build_attrs(attrs, name=name)

--- a/itkufs/reports/migrations/0001_initial.py
+++ b/itkufs/reports/migrations/0001_initial.py
@@ -2,7 +2,6 @@ from django.db import models, migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("accounting", "0001_initial")]
 
     operations = [

--- a/itkufs/reports/migrations/0002_python3.py
+++ b/itkufs/reports/migrations/0002_python3.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0001_initial"),
     ]

--- a/itkufs/reports/migrations/0003_add_sort_order_field.py
+++ b/itkufs/reports/migrations/0003_add_sort_order_field.py
@@ -6,15 +6,24 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('reports', '0002_python3'),
+        ("reports", "0002_python3"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='list',
-            name='sort_order',
-            field=models.CharField(choices=[('Al', 'Alphabetical'), ('Ca', 'Callsign'), ('Co', 'Total consumption'), ('Ra', 'Random')], default='Al', max_length=2, verbose_name='account sort order'),
+            model_name="list",
+            name="sort_order",
+            field=models.CharField(
+                choices=[
+                    ("Al", "Alphabetical"),
+                    ("Ca", "Callsign"),
+                    ("Co", "Total consumption"),
+                    ("Ra", "Random"),
+                ],
+                default="Al",
+                max_length=2,
+                verbose_name="account sort order",
+            ),
         ),
     ]

--- a/itkufs/reports/migrations/0004_auto_20221123_1607.py
+++ b/itkufs/reports/migrations/0004_auto_20221123_1607.py
@@ -6,15 +6,25 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('reports', '0003_add_sort_order_field'),
+        ("reports", "0003_add_sort_order_field"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='list',
-            name='sort_order',
-            field=models.CharField(choices=[('Al', 'Alphabetical'), ('Ca', 'Callsign'), ('Co', 'Total consumption'), ('Ra', 'Random'), ('Lt', 'Last 30 days usage')], default='Al', max_length=2, verbose_name='account sort order'),
+            model_name="list",
+            name="sort_order",
+            field=models.CharField(
+                choices=[
+                    ("Al", "Alphabetical"),
+                    ("Ca", "Callsign"),
+                    ("Co", "Total consumption"),
+                    ("Ra", "Random"),
+                    ("Lt", "Last 30 days usage"),
+                ],
+                default="Al",
+                max_length=2,
+                verbose_name="account sort order",
+            ),
         ),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py37, py38, py39
+envlist = black, flake8, py37, py38, py39
 skipsdist = true
 
 [testenv]
@@ -10,9 +10,15 @@ commands =
         --cov=itkufs --cov-report=term-missing \
         {posargs}
 
+[testenv:black]
+description = Check that the code is formatted with black
+skip_install = true
+deps =
+    black
+commands = black --check itkufs
+
 [testenv:flake8]
 basepython = python3
 deps =
     flake8
-    flake8-black
 commands = python -m flake8 --show-source --statistics itkufs


### PR DESCRIPTION
Reformats the project with the newest version of `black`. This should fix the problems with the pipeline failing, as it was running an unspecified version of `black` through `flake8-black` and throwing errors.

Also replaces `flake8-black` with `black`, as this should be equivalent.