### PR TITLE
fix: Skip adding blocked accounts to PDFs unless 'ignore_blocked' is set

### DIFF
--- a/itkufs/reports/models.py
+++ b/itkufs/reports/models.py
@@ -134,6 +134,9 @@ class List(models.Model):
 
         accounts = []
         for a in all_accounts:
+            if a.is_blocked() and not self.ignore_blocked:
+                continue
+
             if self.add_active_accounts and a.is_user_account():
                 accounts.append(a)
             elif a.id in extra_accounts:


### PR DESCRIPTION
This fixes the bug where a blacklisted account (either because of low balance or manually blacklisted) would still be added to PDFs of lists. Previously, all users belonging to a list would be included when creating a PDF of it, regardless of their status. This means the "Don't exclude blocked accounts" option needs to be enabled for each list if the previous behavior is desired.