### PR TITLE
fix: Add default date range to transaction export form

### DIFF
--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -49,6 +49,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
         writer.writerow(
             [
                 "Entry ID",
+                "Account ID",
                 "Transaction ID",
                 "Date",
                 "Debit",
@@ -65,6 +66,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
             writer.writerow(
                 [
                     e.id,
+                    e.account.id,
                     e.transaction.id,
                     e.transaction.date,
                     e.debit,

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 import csv
+import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -22,9 +23,18 @@ from itkufs.accounting.models import (
 @login_required
 @limit_to_admin
 def export_transactions(request: HttpRequest, group: Group, is_admin=False):
-
-    form = ExportTransactionsForm(data=request.GET)
     filename = f"{group.slug}-transactions.csv"
+
+    if request.GET:
+        # Get form data from request
+        form = ExportTransactionsForm(data=request.GET)
+    else:
+        # Create a new form, set default date range to the last 30 days
+        to_date = datetime.date.today()
+        from_date = to_date - datetime.timedelta(days=30)
+        form = ExportTransactionsForm(
+            initial={"from_date": from_date, "to_date": to_date}
+        )
 
     if form.is_valid():
         response = HttpResponse(content_type="text/csv")

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -48,6 +48,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
         writer = csv.writer(response)
         writer.writerow(
             [
+                "Entry ID",
                 "Transaction ID",
                 "Date",
                 "Debit",
@@ -63,6 +64,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
         for e in entries:
             writer.writerow(
                 [
+                    e.id,
                     e.transaction.id,
                     e.transaction.date,
                     e.debit,

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -57,6 +57,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
                 "Account name",
                 "Short name",
                 "Owner",
+                "Is group account",
             ]
         )
 
@@ -74,6 +75,7 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
                     e.account.name,
                     e.account.short_name,
                     e.account.slug,
+                    e.account.group_account,
                 ]
             )
         return response


### PR DESCRIPTION
Sets a default date range for the "export transactions to CSV"-form (last 30 days).

Also adds entry ID and account ID to the export, to make the CSV files easier to parse.