### PR TITLE
feat: Add date selection for balance/income

### DIFF
--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -3,7 +3,15 @@ import datetime
 from django.conf import settings
 from django.core.mail import send_mail
 from django.db import connection, models, transaction as db_transaction
-from django.db.models import Q
+from django.db.models import (
+    Q,
+    Sum,
+    When,
+    Case,
+    Value,
+    F,
+    ExpressionWrapper,
+)
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.encoding import smart_text
@@ -79,78 +87,6 @@ class Group(models.Model):
             )
             .order_by("transaction__date")
         )
-
-    def get_balance_change(
-        self,
-        from_date: str,
-        to_date: str,
-        include_all_accounts: bool,
-    ):
-        """
-        Returns the change in balance for each account in the group, i.e.
-        the sum of committed transactions in the specified range.
-
-        If include_all_accounts is False, inactive accounts with no
-        balance change are not included.
-        """
-        # Create a dict of all accounts in this group
-        accounts = {
-            a.id: {
-                "id": a.id,
-                "name": a.name,
-                "type": a.type,
-                "is_group_account": a.group_account,
-                "is_active": a.active,
-                "normal_balance": 0,
-            }
-            for a in Account.objects.filter(group=self)
-        }
-
-        for a in self.group_account_set:
-            accounts[a.id]["url"] = a.get_absolute_url()
-
-        # Sum up transactions for all accounts with transactions in the range
-        transaction_filters = (
-            Q(transactionentry__transaction__state=Transaction.COMMITTED_STATE)
-            & Q(transactionentry__transaction__date__gte=from_date)
-            & Q(transactionentry__transaction__date__lte=to_date)
-            & Q(transactionentry__transaction__group=self)
-        )
-        balances = (
-            Account.objects.select_related("transactionentry")
-            .filter(transaction_filters)
-            .annotate(
-                balance=models.Sum("transactionentry__debit")
-                - models.Sum("transactionentry__credit"),
-            )
-            .values(
-                "id",
-                "name",
-                "owner",
-                "short_name",
-                "type",
-                "group_account",
-                "balance",
-            )
-        )
-
-        # Make credit balance positive for liabilities, income and equity
-        for a in balances:
-            if a["type"] in (Account.ASSET_ACCOUNT, Account.EXPENSE_ACCOUNT):
-                accounts[a["id"]]["normal_balance"] = a["balance"]
-            else:
-                accounts[a["id"]]["normal_balance"] = a["balance"] * -1
-
-        if not include_all_accounts:
-            # Filter out inactive accounts with no transactions
-            accounts = {
-                a: accounts[a]
-                for a in accounts
-                if accounts[a]["normal_balance"] != 0
-                or accounts[a]["is_active"]
-            }
-
-        return accounts
 
     def save(self, *args, **kwargs):
         if not len(self.slug):
@@ -308,6 +244,59 @@ class AccountManager(models.Manager):
                     "group_block_limit_sql": GROUP_BLOCK_LIMIT_SQL,
                 }
             )
+        )
+
+    def with_historical_balance(self, at_date):
+        """
+        Returns a queryset of accounts with their normalized balance as of the
+        given date.
+
+        A normalized balance means that equity, liability, and income accounts
+        will have a positive balance if their credit amount is greater than
+        their debit amount.
+        """
+        committed_transactions_at_date = Q(
+            transactionentry__transaction__state=Transaction.COMMITTED_STATE
+        ) & Q(transactionentry__transaction__date__lte=at_date)
+
+        return self.annotate(
+            total_credit=Sum(
+                Case(
+                    When(
+                        committed_transactions_at_date,
+                        then="transactionentry__credit",
+                    ),
+                    default=Value(0),
+                    output_field=models.DecimalField(),
+                )
+            ),
+            total_debit=Sum(
+                Case(
+                    When(
+                        committed_transactions_at_date,
+                        then="transactionentry__debit",
+                    ),
+                    default=Value(0),
+                    output_field=models.DecimalField(),
+                )
+            ),
+        ).annotate(
+            raw_balance=ExpressionWrapper(
+                F("total_debit") - F("total_credit"),
+                output_field=models.DecimalField(),
+            ),
+            normal_balance=Case(
+                When(raw_balance__isnull=True, then=Value(0)),
+                When(
+                    type__in=[
+                        Account.ASSET_ACCOUNT,
+                        Account.EXPENSE_ACCOUNT,
+                    ],
+                    then="raw_balance",
+                ),
+                default=F("raw_balance") * -1,
+                output_field=models.DecimalField(),
+            ),
         )
 
 

--- a/itkufs/accounting/models.py
+++ b/itkufs/accounting/models.py
@@ -70,24 +70,6 @@ class Group(models.Model):
         n = self.account_number
         return ".".join([n[:4], n[4:6], n[6:]])
 
-    def get_all_entries(
-        self, from_date: str, to_date: str
-    ) -> ListType["TransactionEntry"]:
-        """
-        Returns entries for committed transactions for this group, in the
-        range [from_date, to_date] (inclusive).
-        """
-        return (
-            TransactionEntry.objects.filter(transaction__group__id=self.id)
-            .select_related()
-            .filter(
-                transaction__date__gte=from_date,
-                transaction__date__lte=to_date,
-                transaction__state=Transaction.COMMITTED_STATE,
-            )
-            .order_by("transaction__date")
-        )
-
     def save(self, *args, **kwargs):
         if not len(self.slug):
             raise ValueError("Slug cannot be empty.")

--- a/itkufs/common/views/display.py
+++ b/itkufs/common/views/display.py
@@ -17,6 +17,8 @@ from itkufs.common.forms import ExportTransactionsForm
 from itkufs.accounting.models import (
     Account,
     Group,
+    Transaction,
+    TransactionEntry,
 )
 
 
@@ -64,7 +66,17 @@ def export_transactions(request: HttpRequest, group: Group, is_admin=False):
         )
 
         # Find all entries for this group in the given time period
-        entries = group.get_all_entries(from_date, to_date)
+        entries = (
+            TransactionEntry.objects.filter(transaction__group__id=group.id)
+            .select_related()
+            .filter(
+                transaction__date__gte=from_date,
+                transaction__date__lte=to_date,
+                transaction__state=Transaction.COMMITTED_STATE,
+            )
+            .order_by("transaction__date")
+        )
+
         for e in entries:
             writer.writerow(
                 [

--- a/itkufs/locale/no/LC_MESSAGES/django.po
+++ b/itkufs/locale/no/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-09 23:50+0100\n"
+"POT-Creation-Date: 2023-02-23 00:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Stein Magnus Jodal <jodal@samfundet.no>\n"
 "Language-Team: The uFS Developers <itk-ufs@samfundet.no>\n"
@@ -87,268 +87,268 @@ msgstr ""
 "Sett inn mer penger eller ta kontakt med ansvarlig for gruppen for å fikse\n"
 "dette.\n"
 
-#: itkufs/accounting/models.py:15 itkufs/accounting/models.py:258
-#: itkufs/reports/models.py:52 itkufs/reports/models.py:158
+#: itkufs/accounting/models.py:16 itkufs/accounting/models.py:330
+#: itkufs/reports/models.py:52 itkufs/reports/models.py:161
 msgid "name"
 msgstr "navn"
 
-#: itkufs/accounting/models.py:17 itkufs/accounting/models.py:261
+#: itkufs/accounting/models.py:18 itkufs/accounting/models.py:333
 #: itkufs/reports/models.py:53
 msgid "slug"
 msgstr "slug"
 
-#: itkufs/accounting/models.py:17
+#: itkufs/accounting/models.py:18
 msgid "A shortname used in URLs."
 msgstr "Et kortnavn brukt i URL-er."
 
-#: itkufs/accounting/models.py:19
+#: itkufs/accounting/models.py:20
 msgid "admins"
 msgstr "administratorer"
 
-#: itkufs/accounting/models.py:21
+#: itkufs/accounting/models.py:22
 msgid "warn limit"
 msgstr "advarselgrense"
 
-#: itkufs/accounting/models.py:25
+#: itkufs/accounting/models.py:26
 msgid "Warn user of low balance at this limit, leave blank for no limit."
 msgstr "Advar brukere om lav balanse ved denne grensen. Ingen grense hvis tom."
 
-#: itkufs/accounting/models.py:30
+#: itkufs/accounting/models.py:31
 msgid "block limit"
 msgstr "blokkeringsgrense"
 
-#: itkufs/accounting/models.py:33
+#: itkufs/accounting/models.py:34
 msgid "Limit for blacklisting user, leave blank for no limit."
 msgstr "Grense for svartelisting av bruker, tom for ingen grense."
 
-#: itkufs/accounting/models.py:38
+#: itkufs/accounting/models.py:39
 msgid "A small image that will be added to lists."
 msgstr "Lite bilde som vises på lister"
 
-#: itkufs/accounting/models.py:42
+#: itkufs/accounting/models.py:43
 msgid "Contact address for group."
 msgstr "Kontaktadresse for gruppen."
 
-#: itkufs/accounting/models.py:46
+#: itkufs/accounting/models.py:47
 msgid "Bank account for group."
 msgstr "Bankkonto for gruppen."
 
-#: itkufs/accounting/models.py:51 itkufs/accounting/models.py:264
-#: itkufs/accounting/models.py:445 itkufs/accounting/models.py:490
-#: itkufs/accounting/models.py:558 itkufs/reports/models.py:67
+#: itkufs/accounting/models.py:52 itkufs/accounting/models.py:336
+#: itkufs/accounting/models.py:517 itkufs/accounting/models.py:562
+#: itkufs/accounting/models.py:630 itkufs/reports/models.py:67
 msgid "group"
 msgstr "gruppe"
 
-#: itkufs/accounting/models.py:52
+#: itkufs/accounting/models.py:53
 msgid "groups"
 msgstr "grupper"
 
-#: itkufs/accounting/models.py:74
+#: itkufs/accounting/models.py:164
 msgid "Bank"
 msgstr "Bank"
 
-#: itkufs/accounting/models.py:87
+#: itkufs/accounting/models.py:177
 msgid "Cash"
 msgstr "Kontanter"
 
-#: itkufs/accounting/models.py:249
+#: itkufs/accounting/models.py:321
 msgid "Asset"
 msgstr "Eiendel/aktiva"
 
-#: itkufs/accounting/models.py:250
+#: itkufs/accounting/models.py:322
 msgid "Liability"
 msgstr "Gjeld/passiva"
 
-#: itkufs/accounting/models.py:251
+#: itkufs/accounting/models.py:323
 msgid "Equity"
 msgstr "Egenkapital"
 
-#: itkufs/accounting/models.py:252
+#: itkufs/accounting/models.py:324
 msgid "Income"
 msgstr "Inntekt"
 
-#: itkufs/accounting/models.py:253
+#: itkufs/accounting/models.py:325
 msgid "Expense"
 msgstr "Utgift"
 
-#: itkufs/accounting/models.py:259
+#: itkufs/accounting/models.py:331
 msgid "short name"
 msgstr "Kortnavn"
 
-#: itkufs/accounting/models.py:261
+#: itkufs/accounting/models.py:333
 msgid "A shortname used in URLs etc."
 msgstr "Et kortnavn brukt i URL-er o.l."
 
-#: itkufs/accounting/models.py:267 itkufs/accounting/models.py:768
+#: itkufs/accounting/models.py:339 itkufs/accounting/models.py:840
 msgid "type"
 msgstr "type"
 
-#: itkufs/accounting/models.py:274
+#: itkufs/accounting/models.py:346
 msgid "owner"
 msgstr "eier"
 
-#: itkufs/accounting/models.py:276
+#: itkufs/accounting/models.py:348
 msgid "active"
 msgstr "aktiv"
 
-#: itkufs/accounting/models.py:278
+#: itkufs/accounting/models.py:350
 msgid "ignore block limit"
 msgstr "ignorer blokkeringsgrense"
 
-#: itkufs/accounting/models.py:280
+#: itkufs/accounting/models.py:352
 msgid "Never block account automatically"
 msgstr "Ikke merk konto som svartelistet automagisk"
 
-#: itkufs/accounting/models.py:283
+#: itkufs/accounting/models.py:355
 msgid "blocked"
 msgstr "svartelistet"
 
-#: itkufs/accounting/models.py:283
+#: itkufs/accounting/models.py:355
 msgid "Block account manually"
 msgstr "Merk konto som svartelistet"
 
-#: itkufs/accounting/models.py:286
+#: itkufs/accounting/models.py:358
 msgid "group account"
 msgstr "Gruppekonto"
 
-#: itkufs/accounting/models.py:288
+#: itkufs/accounting/models.py:360
 msgid "Does this account belong to the group?"
 msgstr "Hører denne kontoen til gruppen?"
 
-#: itkufs/accounting/models.py:294 itkufs/accounting/models.py:449
-#: itkufs/accounting/models.py:826
+#: itkufs/accounting/models.py:366 itkufs/accounting/models.py:521
+#: itkufs/accounting/models.py:898
 msgid "account"
 msgstr "konto"
 
-#: itkufs/accounting/models.py:295
+#: itkufs/accounting/models.py:367
 msgid "accounts"
 msgstr "kontoer"
 
-#: itkufs/accounting/models.py:439
+#: itkufs/accounting/models.py:511
 msgid "Bank account"
 msgstr "Bankkonto"
 
-#: itkufs/accounting/models.py:440
+#: itkufs/accounting/models.py:512
 msgid "Cash account"
 msgstr "Kontantkonto"
 
-#: itkufs/accounting/models.py:441
+#: itkufs/accounting/models.py:513
 msgid "Sale account"
 msgstr "Salgskonto"
 
-#: itkufs/accounting/models.py:447
+#: itkufs/accounting/models.py:519
 msgid "role"
 msgstr "rolle"
 
-#: itkufs/accounting/models.py:456
+#: itkufs/accounting/models.py:528
 msgid "role account"
 msgstr "rollekonto"
 
-#: itkufs/accounting/models.py:457
+#: itkufs/accounting/models.py:529
 msgid "role accounts"
 msgstr "rollekontoer"
 
-#: itkufs/accounting/models.py:460
+#: itkufs/accounting/models.py:532
 #, python-format
 msgid "%(account)s is %(role)s for %(group)s"
 msgstr "%(account)s er %(role)s for %(group)s"
 
-#: itkufs/accounting/models.py:492 itkufs/accounting/models.py:569
+#: itkufs/accounting/models.py:564 itkufs/accounting/models.py:641
 msgid "date"
 msgstr "dato"
 
-#: itkufs/accounting/models.py:493 itkufs/reports/models.py:96
+#: itkufs/accounting/models.py:565 itkufs/reports/models.py:96
 msgid "comment"
 msgstr "kommentar"
 
-#: itkufs/accounting/models.py:497
+#: itkufs/accounting/models.py:569
 msgid "Mark as closed when done adding transactions to the settlement."
 msgstr "Sett som avsluttet når du er ferdig med å legge til transaksjoner."
 
-#: itkufs/accounting/models.py:503 itkufs/accounting/models.py:564
+#: itkufs/accounting/models.py:575 itkufs/accounting/models.py:636
 msgid "settlement"
 msgstr "oppgjør"
 
-#: itkufs/accounting/models.py:504
+#: itkufs/accounting/models.py:576
 msgid "settlements"
 msgstr "oppgjør"
 
-#: itkufs/accounting/models.py:548 itkufs/billing/models.py:25
+#: itkufs/accounting/models.py:620 itkufs/billing/models.py:25
 msgid "Pending"
 msgstr "Avventer"
 
-#: itkufs/accounting/models.py:549 itkufs/billing/models.py:27
+#: itkufs/accounting/models.py:621 itkufs/billing/models.py:27
 msgid "Committed"
 msgstr "Godkjent"
 
-#: itkufs/accounting/models.py:550
+#: itkufs/accounting/models.py:622
 msgid "Rejected"
 msgstr "Avvist"
 
-#: itkufs/accounting/models.py:571
+#: itkufs/accounting/models.py:643
 msgid "May be used for date of the transaction if not today."
 msgstr "Kan brukes for transaksjonsdato, hvis ikke i dag."
 
-#: itkufs/accounting/models.py:573
+#: itkufs/accounting/models.py:645
 #: itkufs/templates/accounting/transaction_details.html:39
 msgid "Last modified"
 msgstr "Sist endret"
 
-#: itkufs/accounting/models.py:575
+#: itkufs/accounting/models.py:647
 msgid "state"
 msgstr "tilstand"
 
-#: itkufs/accounting/models.py:580 itkufs/accounting/models.py:764
-#: itkufs/accounting/models.py:822
+#: itkufs/accounting/models.py:652 itkufs/accounting/models.py:836
+#: itkufs/accounting/models.py:894
 msgid "transaction"
 msgstr "transaksjon"
 
-#: itkufs/accounting/models.py:581
+#: itkufs/accounting/models.py:653
 msgid "transactions"
 msgstr "transaksjoner"
 
-#: itkufs/accounting/models.py:770
+#: itkufs/accounting/models.py:842
 msgid "timestamp"
 msgstr "tidsstempel"
 
-#: itkufs/accounting/models.py:772
+#: itkufs/accounting/models.py:844
 msgid "user"
 msgstr "bruker"
 
-#: itkufs/accounting/models.py:774
+#: itkufs/accounting/models.py:846
 msgid "message"
 msgstr "melding"
 
-#: itkufs/accounting/models.py:794
+#: itkufs/accounting/models.py:866
 msgid "transaction log entry"
 msgstr "transaksjonslogginnslag"
 
-#: itkufs/accounting/models.py:795
+#: itkufs/accounting/models.py:867
 msgid "transaction log entries"
 msgstr "transaksjonlogginnslag"
 
-#: itkufs/accounting/models.py:807
+#: itkufs/accounting/models.py:879
 #, python-format
 msgid "%(type)s at %(timestamp)s by %(user)s: %(message)s"
 msgstr "%(type)s ved %(timestamp)s av %(user)s: %(message)s"
 
-#: itkufs/accounting/models.py:829
+#: itkufs/accounting/models.py:901
 msgid "debit amount"
 msgstr "debetbeløp"
 
-#: itkufs/accounting/models.py:832
+#: itkufs/accounting/models.py:904
 msgid "credit amount"
 msgstr "kreditbeløp"
 
-#: itkufs/accounting/models.py:884
+#: itkufs/accounting/models.py:955
 msgid "transaction entry"
 msgstr "transaksjonsinnslag"
 
-#: itkufs/accounting/models.py:885
+#: itkufs/accounting/models.py:956
 msgid "transaction entries"
 msgstr "transaksjonsinnslag"
 
-#: itkufs/accounting/models.py:889
+#: itkufs/accounting/models.py:960
 #, python-format
 msgid "%(account)s: debit %(debit)s, credit %(credit)s"
 msgstr "%(account)s: debet %(debit)s, kredit %(credit)s"
@@ -505,15 +505,17 @@ msgstr "Det er ikke mulig å fjerne dine egne administratorrettigheter."
 msgid "Incorrect account number."
 msgstr "Feil kontonummer."
 
-#: itkufs/common/forms.py:197
+#: itkufs/common/forms.py:197 itkufs/reports/forms.py:182
 msgid "From date"
 msgstr "Fra dato"
 
 #: itkufs/common/forms.py:199 itkufs/common/forms.py:204
+#: itkufs/reports/forms.py:167 itkufs/reports/forms.py:184
+#: itkufs/reports/forms.py:189
 msgid "Please enter a date"
 msgstr "Vennligst oppgi en dato"
 
-#: itkufs/common/forms.py:202
+#: itkufs/common/forms.py:202 itkufs/reports/forms.py:187
 msgid "To date"
 msgstr "Til dato"
 
@@ -537,7 +539,7 @@ msgstr "Kontoen er oppdatert."
 msgid "Account successfully created."
 msgstr "Kontoen er opprettet."
 
-#: itkufs/common/widgets.py:78
+#: itkufs/common/widgets.py:77
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr "Du må velge et at de tilgjengelige valgene"
 
@@ -557,6 +559,33 @@ msgstr "Mangler navn"
 #: itkufs/reports/forms.py:154
 msgid "Width missing"
 msgstr "Mangler bredde"
+
+#: itkufs/reports/forms.py:165
+#: itkufs/templates/accounting/approve_transactions.html:44
+#: itkufs/templates/accounting/settlement_details.html:19
+#: itkufs/templates/accounting/settlement_list.html:41
+#: itkufs/templates/accounting/transaction_details.html:35
+#: itkufs/templates/accounting/transaction_list_table.html:7
+#: itkufs/templates/billing/bill_list.html:13
+msgid "Date"
+msgstr "Dato"
+
+#: itkufs/reports/forms.py:170 itkufs/reports/forms.py:192
+#: itkufs/templates/common/group_summary.html:113
+#: itkufs/templates/common/group_summary.html:117
+#: itkufs/templates/reports/list_transaction_form.html:31
+msgid "Accounts"
+msgstr "Kontoer"
+
+#: itkufs/reports/forms.py:172 itkufs/reports/forms.py:194
+#: itkufs/templates/common/group_summary.html:182
+msgid "Hide inactive accounts"
+msgstr "Skjul inaktive kontoer"
+
+#: itkufs/reports/forms.py:173 itkufs/reports/forms.py:195
+#: itkufs/templates/common/group_summary.html:184
+msgid "Show all accounts"
+msgstr "Vis inaktive kontoer"
 
 #: itkufs/reports/models.py:37
 msgid "Landscape"
@@ -643,7 +672,7 @@ msgstr "ignorer blokkeringsgrense"
 msgid "Don't exclude blocked accounts"
 msgstr "Ta med svartelistede kontoer"
 
-#: itkufs/reports/models.py:112 itkufs/reports/models.py:163
+#: itkufs/reports/models.py:112 itkufs/reports/models.py:166
 msgid "list"
 msgstr "liste"
 
@@ -651,15 +680,15 @@ msgstr "liste"
 msgid "lists"
 msgstr "lister"
 
-#: itkufs/reports/models.py:159
+#: itkufs/reports/models.py:162
 msgid "width"
 msgstr "bredde"
 
-#: itkufs/reports/models.py:170
+#: itkufs/reports/models.py:173
 msgid "list item"
 msgstr "listeelement"
 
-#: itkufs/reports/models.py:171
+#: itkufs/reports/models.py:174
 msgid "list items"
 msgstr "listeelementer"
 
@@ -699,24 +728,24 @@ msgstr "Navn"
 msgid "Balance"
 msgstr "Balanse"
 
-#: itkufs/reports/views.py:182
+#: itkufs/reports/views.py:196
 msgid "List deleted."
 msgstr "Listen ble slettet."
 
-#: itkufs/reports/views.py:215
+#: itkufs/reports/views.py:229
 #, python-format
 msgid "Created from list: %s"
 msgstr "Laget fra liste: %s"
 
-#: itkufs/reports/views.py:273
+#: itkufs/reports/views.py:301
 msgid "Positive member accounts"
 msgstr "Positive medlemskontoer"
 
-#: itkufs/reports/views.py:274
+#: itkufs/reports/views.py:304
 msgid "Negative member accounts"
 msgstr "Negative medlemskontoer"
 
-#: itkufs/reports/views.py:289
+#: itkufs/reports/views.py:315
 msgid "Current year's net income"
 msgstr "Nettoinntekt inneværende år"
 
@@ -782,15 +811,6 @@ msgstr "Ingen transaksjoner funnet."
 msgid "ID"
 msgstr "ID"
 
-#: itkufs/templates/accounting/approve_transactions.html:44
-#: itkufs/templates/accounting/settlement_details.html:19
-#: itkufs/templates/accounting/settlement_list.html:41
-#: itkufs/templates/accounting/transaction_details.html:35
-#: itkufs/templates/accounting/transaction_list_table.html:7
-#: itkufs/templates/billing/bill_list.html:13
-msgid "Date"
-msgstr "Dato"
-
 #: itkufs/templates/accounting/approve_transactions.html:45
 #: itkufs/templates/accounting/transaction_details.html:69
 #: itkufs/templates/accounting/transaction_form.html:67
@@ -830,6 +850,8 @@ msgid "No transaction log message"
 msgstr "Ingen melding i transaksjonsloggen"
 
 #: itkufs/templates/accounting/approve_transactions.html:107
+#: itkufs/templates/reports/balance.html:36
+#: itkufs/templates/reports/income.html:35
 msgid "Update"
 msgstr "Oppdater"
 
@@ -1359,12 +1381,6 @@ msgstr "Slett listen"
 msgid "New list"
 msgstr "Ny liste"
 
-#: itkufs/templates/common/group_summary.html:113
-#: itkufs/templates/common/group_summary.html:117
-#: itkufs/templates/reports/list_transaction_form.html:31
-msgid "Accounts"
-msgstr "Kontoer"
-
 #: itkufs/templates/common/group_summary.html:114
 msgid "No accounts found."
 msgstr "Finner ingen kontoer."
@@ -1376,14 +1392,6 @@ msgstr "Medlemskontoer"
 #: itkufs/templates/common/group_summary.html:152
 msgid "Group accounts"
 msgstr "Gruppekontoer"
-
-#: itkufs/templates/common/group_summary.html:182
-msgid "Hide inactive accounts"
-msgstr "Skjul inaktive kontoer"
-
-#: itkufs/templates/common/group_summary.html:184
-msgid "Show all accounts"
-msgstr "Vis inaktive kontoer"
 
 #: itkufs/templates/common/no_account.html:10
 #: itkufs/templates/common/no_account.html:17
@@ -1410,35 +1418,39 @@ msgstr ""
 msgid "Save role accounts"
 msgstr "Lagre rollekontoer"
 
-#: itkufs/templates/reports/balance.html:30
+#: itkufs/templates/reports/balance.html:28
+msgid "Select a date to see account balances at that date."
+msgstr "Velg en dato for å se saldo for kontoene på den datoen."
+
+#: itkufs/templates/reports/balance.html:44
 msgid "Assets"
 msgstr "Eiendeler"
 
-#: itkufs/templates/reports/balance.html:45
+#: itkufs/templates/reports/balance.html:59
 msgid "Total assets"
 msgstr "Totale eiendeler"
 
-#: itkufs/templates/reports/balance.html:56
+#: itkufs/templates/reports/balance.html:70
 msgid "Liabilities and equities"
 msgstr "Egenkapital og gjeld"
 
-#: itkufs/templates/reports/balance.html:60
+#: itkufs/templates/reports/balance.html:74
 msgid "Liabilities"
 msgstr "Gjeld"
 
-#: itkufs/templates/reports/balance.html:81
+#: itkufs/templates/reports/balance.html:95
 msgid "Total liabilities"
 msgstr "Total gjeld"
 
-#: itkufs/templates/reports/balance.html:88
+#: itkufs/templates/reports/balance.html:102
 msgid "Equities"
 msgstr "Egenkapital"
 
-#: itkufs/templates/reports/balance.html:109
+#: itkufs/templates/reports/balance.html:123
 msgid "Total equities (Net worth)"
 msgstr "Total egenkapital (nettoverdi)"
 
-#: itkufs/templates/reports/balance.html:116
+#: itkufs/templates/reports/balance.html:130
 msgid "Total liabilities and equities"
 msgstr "Total egenkapital og gjeld"
 
@@ -1446,27 +1458,27 @@ msgstr "Total egenkapital og gjeld"
 msgid "Reports"
 msgstr "Rapporter"
 
-#: itkufs/templates/reports/income.html:20
-msgid "up to"
-msgstr "opp til"
+#: itkufs/templates/reports/income.html:27
+msgid "Specify a date range to see incomes and expenses for that period."
+msgstr "Velg en periode for å se inntekter og utgifter for den perioden."
 
-#: itkufs/templates/reports/income.html:30
+#: itkufs/templates/reports/income.html:40
 msgid "Revenues and gains"
 msgstr "Inntekter og gevinster"
 
-#: itkufs/templates/reports/income.html:45
+#: itkufs/templates/reports/income.html:55
 msgid "Total revenues and gains"
 msgstr "Totale inntekter og gevinster"
 
-#: itkufs/templates/reports/income.html:54
+#: itkufs/templates/reports/income.html:64
 msgid "Expenses and losses"
 msgstr "Utgifter og tap"
 
-#: itkufs/templates/reports/income.html:69
+#: itkufs/templates/reports/income.html:79
 msgid "Total expenses and losses"
 msgstr "Totale utgifter og tap"
 
-#: itkufs/templates/reports/income.html:76
+#: itkufs/templates/reports/income.html:86
 msgid "Net income"
 msgstr "Nettoinntekt"
 

--- a/itkufs/locale/no/LC_MESSAGES/django.po
+++ b/itkufs/locale/no/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-23 00:06+0100\n"
+"POT-Creation-Date: 2023-02-26 11:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Stein Magnus Jodal <jodal@samfundet.no>\n"
 "Language-Team: The uFS Developers <itk-ufs@samfundet.no>\n"
@@ -87,268 +87,268 @@ msgstr ""
 "Sett inn mer penger eller ta kontakt med ansvarlig for gruppen for å fikse\n"
 "dette.\n"
 
-#: itkufs/accounting/models.py:16 itkufs/accounting/models.py:330
+#: itkufs/accounting/models.py:24 itkufs/accounting/models.py:319
 #: itkufs/reports/models.py:52 itkufs/reports/models.py:161
 msgid "name"
 msgstr "navn"
 
-#: itkufs/accounting/models.py:18 itkufs/accounting/models.py:333
+#: itkufs/accounting/models.py:26 itkufs/accounting/models.py:322
 #: itkufs/reports/models.py:53
 msgid "slug"
 msgstr "slug"
 
-#: itkufs/accounting/models.py:18
+#: itkufs/accounting/models.py:26
 msgid "A shortname used in URLs."
 msgstr "Et kortnavn brukt i URL-er."
 
-#: itkufs/accounting/models.py:20
+#: itkufs/accounting/models.py:28
 msgid "admins"
 msgstr "administratorer"
 
-#: itkufs/accounting/models.py:22
+#: itkufs/accounting/models.py:30
 msgid "warn limit"
 msgstr "advarselgrense"
 
-#: itkufs/accounting/models.py:26
+#: itkufs/accounting/models.py:34
 msgid "Warn user of low balance at this limit, leave blank for no limit."
 msgstr "Advar brukere om lav balanse ved denne grensen. Ingen grense hvis tom."
 
-#: itkufs/accounting/models.py:31
+#: itkufs/accounting/models.py:39
 msgid "block limit"
 msgstr "blokkeringsgrense"
 
-#: itkufs/accounting/models.py:34
+#: itkufs/accounting/models.py:42
 msgid "Limit for blacklisting user, leave blank for no limit."
 msgstr "Grense for svartelisting av bruker, tom for ingen grense."
 
-#: itkufs/accounting/models.py:39
+#: itkufs/accounting/models.py:47
 msgid "A small image that will be added to lists."
 msgstr "Lite bilde som vises på lister"
 
-#: itkufs/accounting/models.py:43
+#: itkufs/accounting/models.py:51
 msgid "Contact address for group."
 msgstr "Kontaktadresse for gruppen."
 
-#: itkufs/accounting/models.py:47
+#: itkufs/accounting/models.py:55
 msgid "Bank account for group."
 msgstr "Bankkonto for gruppen."
 
-#: itkufs/accounting/models.py:52 itkufs/accounting/models.py:336
-#: itkufs/accounting/models.py:517 itkufs/accounting/models.py:562
-#: itkufs/accounting/models.py:630 itkufs/reports/models.py:67
+#: itkufs/accounting/models.py:60 itkufs/accounting/models.py:325
+#: itkufs/accounting/models.py:506 itkufs/accounting/models.py:551
+#: itkufs/accounting/models.py:619 itkufs/reports/models.py:67
 msgid "group"
 msgstr "gruppe"
 
-#: itkufs/accounting/models.py:53
+#: itkufs/accounting/models.py:61
 msgid "groups"
 msgstr "grupper"
 
-#: itkufs/accounting/models.py:164
+#: itkufs/accounting/models.py:100
 msgid "Bank"
 msgstr "Bank"
 
-#: itkufs/accounting/models.py:177
+#: itkufs/accounting/models.py:113
 msgid "Cash"
 msgstr "Kontanter"
 
-#: itkufs/accounting/models.py:321
+#: itkufs/accounting/models.py:310
 msgid "Asset"
 msgstr "Eiendel/aktiva"
 
-#: itkufs/accounting/models.py:322
+#: itkufs/accounting/models.py:311
 msgid "Liability"
 msgstr "Gjeld/passiva"
 
-#: itkufs/accounting/models.py:323
+#: itkufs/accounting/models.py:312
 msgid "Equity"
 msgstr "Egenkapital"
 
-#: itkufs/accounting/models.py:324
+#: itkufs/accounting/models.py:313
 msgid "Income"
 msgstr "Inntekt"
 
-#: itkufs/accounting/models.py:325
+#: itkufs/accounting/models.py:314
 msgid "Expense"
 msgstr "Utgift"
 
-#: itkufs/accounting/models.py:331
+#: itkufs/accounting/models.py:320
 msgid "short name"
 msgstr "Kortnavn"
 
-#: itkufs/accounting/models.py:333
+#: itkufs/accounting/models.py:322
 msgid "A shortname used in URLs etc."
 msgstr "Et kortnavn brukt i URL-er o.l."
 
-#: itkufs/accounting/models.py:339 itkufs/accounting/models.py:840
+#: itkufs/accounting/models.py:328 itkufs/accounting/models.py:829
 msgid "type"
 msgstr "type"
 
-#: itkufs/accounting/models.py:346
+#: itkufs/accounting/models.py:335
 msgid "owner"
 msgstr "eier"
 
-#: itkufs/accounting/models.py:348
+#: itkufs/accounting/models.py:337
 msgid "active"
 msgstr "aktiv"
 
-#: itkufs/accounting/models.py:350
+#: itkufs/accounting/models.py:339
 msgid "ignore block limit"
 msgstr "ignorer blokkeringsgrense"
 
-#: itkufs/accounting/models.py:352
+#: itkufs/accounting/models.py:341
 msgid "Never block account automatically"
 msgstr "Ikke merk konto som svartelistet automagisk"
 
-#: itkufs/accounting/models.py:355
+#: itkufs/accounting/models.py:344
 msgid "blocked"
 msgstr "svartelistet"
 
-#: itkufs/accounting/models.py:355
+#: itkufs/accounting/models.py:344
 msgid "Block account manually"
 msgstr "Merk konto som svartelistet"
 
-#: itkufs/accounting/models.py:358
+#: itkufs/accounting/models.py:347
 msgid "group account"
 msgstr "Gruppekonto"
 
-#: itkufs/accounting/models.py:360
+#: itkufs/accounting/models.py:349
 msgid "Does this account belong to the group?"
 msgstr "Hører denne kontoen til gruppen?"
 
-#: itkufs/accounting/models.py:366 itkufs/accounting/models.py:521
-#: itkufs/accounting/models.py:898
+#: itkufs/accounting/models.py:355 itkufs/accounting/models.py:510
+#: itkufs/accounting/models.py:887
 msgid "account"
 msgstr "konto"
 
-#: itkufs/accounting/models.py:367
+#: itkufs/accounting/models.py:356
 msgid "accounts"
 msgstr "kontoer"
 
-#: itkufs/accounting/models.py:511
+#: itkufs/accounting/models.py:500
 msgid "Bank account"
 msgstr "Bankkonto"
 
-#: itkufs/accounting/models.py:512
+#: itkufs/accounting/models.py:501
 msgid "Cash account"
 msgstr "Kontantkonto"
 
-#: itkufs/accounting/models.py:513
+#: itkufs/accounting/models.py:502
 msgid "Sale account"
 msgstr "Salgskonto"
 
-#: itkufs/accounting/models.py:519
+#: itkufs/accounting/models.py:508
 msgid "role"
 msgstr "rolle"
 
-#: itkufs/accounting/models.py:528
+#: itkufs/accounting/models.py:517
 msgid "role account"
 msgstr "rollekonto"
 
-#: itkufs/accounting/models.py:529
+#: itkufs/accounting/models.py:518
 msgid "role accounts"
 msgstr "rollekontoer"
 
-#: itkufs/accounting/models.py:532
+#: itkufs/accounting/models.py:521
 #, python-format
 msgid "%(account)s is %(role)s for %(group)s"
 msgstr "%(account)s er %(role)s for %(group)s"
 
-#: itkufs/accounting/models.py:564 itkufs/accounting/models.py:641
+#: itkufs/accounting/models.py:553 itkufs/accounting/models.py:630
 msgid "date"
 msgstr "dato"
 
-#: itkufs/accounting/models.py:565 itkufs/reports/models.py:96
+#: itkufs/accounting/models.py:554 itkufs/reports/models.py:96
 msgid "comment"
 msgstr "kommentar"
 
-#: itkufs/accounting/models.py:569
+#: itkufs/accounting/models.py:558
 msgid "Mark as closed when done adding transactions to the settlement."
 msgstr "Sett som avsluttet når du er ferdig med å legge til transaksjoner."
 
-#: itkufs/accounting/models.py:575 itkufs/accounting/models.py:636
+#: itkufs/accounting/models.py:564 itkufs/accounting/models.py:625
 msgid "settlement"
 msgstr "oppgjør"
 
-#: itkufs/accounting/models.py:576
+#: itkufs/accounting/models.py:565
 msgid "settlements"
 msgstr "oppgjør"
 
-#: itkufs/accounting/models.py:620 itkufs/billing/models.py:25
+#: itkufs/accounting/models.py:609 itkufs/billing/models.py:25
 msgid "Pending"
 msgstr "Avventer"
 
-#: itkufs/accounting/models.py:621 itkufs/billing/models.py:27
+#: itkufs/accounting/models.py:610 itkufs/billing/models.py:27
 msgid "Committed"
 msgstr "Godkjent"
 
-#: itkufs/accounting/models.py:622
+#: itkufs/accounting/models.py:611
 msgid "Rejected"
 msgstr "Avvist"
 
-#: itkufs/accounting/models.py:643
+#: itkufs/accounting/models.py:632
 msgid "May be used for date of the transaction if not today."
 msgstr "Kan brukes for transaksjonsdato, hvis ikke i dag."
 
-#: itkufs/accounting/models.py:645
+#: itkufs/accounting/models.py:634
 #: itkufs/templates/accounting/transaction_details.html:39
 msgid "Last modified"
 msgstr "Sist endret"
 
-#: itkufs/accounting/models.py:647
+#: itkufs/accounting/models.py:636
 msgid "state"
 msgstr "tilstand"
 
-#: itkufs/accounting/models.py:652 itkufs/accounting/models.py:836
-#: itkufs/accounting/models.py:894
+#: itkufs/accounting/models.py:641 itkufs/accounting/models.py:825
+#: itkufs/accounting/models.py:883
 msgid "transaction"
 msgstr "transaksjon"
 
-#: itkufs/accounting/models.py:653
+#: itkufs/accounting/models.py:642
 msgid "transactions"
 msgstr "transaksjoner"
 
-#: itkufs/accounting/models.py:842
+#: itkufs/accounting/models.py:831
 msgid "timestamp"
 msgstr "tidsstempel"
 
-#: itkufs/accounting/models.py:844
+#: itkufs/accounting/models.py:833
 msgid "user"
 msgstr "bruker"
 
-#: itkufs/accounting/models.py:846
+#: itkufs/accounting/models.py:835
 msgid "message"
 msgstr "melding"
 
-#: itkufs/accounting/models.py:866
+#: itkufs/accounting/models.py:855
 msgid "transaction log entry"
 msgstr "transaksjonslogginnslag"
 
-#: itkufs/accounting/models.py:867
+#: itkufs/accounting/models.py:856
 msgid "transaction log entries"
 msgstr "transaksjonlogginnslag"
 
-#: itkufs/accounting/models.py:879
+#: itkufs/accounting/models.py:868
 #, python-format
 msgid "%(type)s at %(timestamp)s by %(user)s: %(message)s"
 msgstr "%(type)s ved %(timestamp)s av %(user)s: %(message)s"
 
-#: itkufs/accounting/models.py:901
+#: itkufs/accounting/models.py:890
 msgid "debit amount"
 msgstr "debetbeløp"
 
-#: itkufs/accounting/models.py:904
+#: itkufs/accounting/models.py:893
 msgid "credit amount"
 msgstr "kreditbeløp"
 
-#: itkufs/accounting/models.py:955
+#: itkufs/accounting/models.py:944
 msgid "transaction entry"
 msgstr "transaksjonsinnslag"
 
-#: itkufs/accounting/models.py:956
+#: itkufs/accounting/models.py:945
 msgid "transaction entries"
 msgstr "transaksjonsinnslag"
 
-#: itkufs/accounting/models.py:960
+#: itkufs/accounting/models.py:949
 #, python-format
 msgid "%(account)s: debit %(debit)s, credit %(credit)s"
 msgstr "%(account)s: debet %(debit)s, kredit %(credit)s"
@@ -505,17 +505,17 @@ msgstr "Det er ikke mulig å fjerne dine egne administratorrettigheter."
 msgid "Incorrect account number."
 msgstr "Feil kontonummer."
 
-#: itkufs/common/forms.py:197 itkufs/reports/forms.py:182
+#: itkufs/common/forms.py:197 itkufs/reports/forms.py:181
 msgid "From date"
 msgstr "Fra dato"
 
 #: itkufs/common/forms.py:199 itkufs/common/forms.py:204
-#: itkufs/reports/forms.py:167 itkufs/reports/forms.py:184
-#: itkufs/reports/forms.py:189
+#: itkufs/reports/forms.py:167 itkufs/reports/forms.py:183
+#: itkufs/reports/forms.py:188
 msgid "Please enter a date"
 msgstr "Vennligst oppgi en dato"
 
-#: itkufs/common/forms.py:202 itkufs/reports/forms.py:187
+#: itkufs/common/forms.py:202 itkufs/reports/forms.py:186
 msgid "To date"
 msgstr "Til dato"
 
@@ -570,22 +570,13 @@ msgstr "Mangler bredde"
 msgid "Date"
 msgstr "Dato"
 
-#: itkufs/reports/forms.py:170 itkufs/reports/forms.py:192
-#: itkufs/templates/common/group_summary.html:113
-#: itkufs/templates/common/group_summary.html:117
-#: itkufs/templates/reports/list_transaction_form.html:31
-msgid "Accounts"
-msgstr "Kontoer"
+#: itkufs/reports/forms.py:170 itkufs/reports/forms.py:191
+msgid "Hide empty active accounts"
+msgstr "Skjul tomme aktive kontoer"
 
-#: itkufs/reports/forms.py:172 itkufs/reports/forms.py:194
-#: itkufs/templates/common/group_summary.html:182
-msgid "Hide inactive accounts"
-msgstr "Skjul inaktive kontoer"
-
-#: itkufs/reports/forms.py:173 itkufs/reports/forms.py:195
-#: itkufs/templates/common/group_summary.html:184
-msgid "Show all accounts"
-msgstr "Vis inaktive kontoer"
+#: itkufs/reports/forms.py:174 itkufs/reports/forms.py:195
+msgid "Hide empty inactive accounts"
+msgstr "Skjul tomme inaktive kontoer"
 
 #: itkufs/reports/models.py:37
 msgid "Landscape"
@@ -728,24 +719,24 @@ msgstr "Navn"
 msgid "Balance"
 msgstr "Balanse"
 
-#: itkufs/reports/views.py:196
+#: itkufs/reports/views.py:194
 msgid "List deleted."
 msgstr "Listen ble slettet."
 
-#: itkufs/reports/views.py:229
+#: itkufs/reports/views.py:227
 #, python-format
 msgid "Created from list: %s"
 msgstr "Laget fra liste: %s"
 
-#: itkufs/reports/views.py:301
+#: itkufs/reports/views.py:310
 msgid "Positive member accounts"
 msgstr "Positive medlemskontoer"
 
-#: itkufs/reports/views.py:304
+#: itkufs/reports/views.py:313
 msgid "Negative member accounts"
 msgstr "Negative medlemskontoer"
 
-#: itkufs/reports/views.py:315
+#: itkufs/reports/views.py:324
 msgid "Current year's net income"
 msgstr "Nettoinntekt inneværende år"
 
@@ -850,8 +841,8 @@ msgid "No transaction log message"
 msgstr "Ingen melding i transaksjonsloggen"
 
 #: itkufs/templates/accounting/approve_transactions.html:107
-#: itkufs/templates/reports/balance.html:36
-#: itkufs/templates/reports/income.html:35
+#: itkufs/templates/reports/balance.html:34
+#: itkufs/templates/reports/income.html:33
 msgid "Update"
 msgstr "Oppdater"
 
@@ -1381,6 +1372,12 @@ msgstr "Slett listen"
 msgid "New list"
 msgstr "Ny liste"
 
+#: itkufs/templates/common/group_summary.html:113
+#: itkufs/templates/common/group_summary.html:117
+#: itkufs/templates/reports/list_transaction_form.html:31
+msgid "Accounts"
+msgstr "Kontoer"
+
 #: itkufs/templates/common/group_summary.html:114
 msgid "No accounts found."
 msgstr "Finner ingen kontoer."
@@ -1392,6 +1389,14 @@ msgstr "Medlemskontoer"
 #: itkufs/templates/common/group_summary.html:152
 msgid "Group accounts"
 msgstr "Gruppekontoer"
+
+#: itkufs/templates/common/group_summary.html:182
+msgid "Hide inactive accounts"
+msgstr "Skjul inaktive kontoer"
+
+#: itkufs/templates/common/group_summary.html:184
+msgid "Show all accounts"
+msgstr "Vis inaktive kontoer"
 
 #: itkufs/templates/common/no_account.html:10
 #: itkufs/templates/common/no_account.html:17
@@ -1422,35 +1427,35 @@ msgstr "Lagre rollekontoer"
 msgid "Select a date to see account balances at that date."
 msgstr "Velg en dato for å se saldo for kontoene på den datoen."
 
-#: itkufs/templates/reports/balance.html:44
+#: itkufs/templates/reports/balance.html:41
 msgid "Assets"
 msgstr "Eiendeler"
 
-#: itkufs/templates/reports/balance.html:59
+#: itkufs/templates/reports/balance.html:56
 msgid "Total assets"
 msgstr "Totale eiendeler"
 
-#: itkufs/templates/reports/balance.html:70
+#: itkufs/templates/reports/balance.html:67
 msgid "Liabilities and equities"
 msgstr "Egenkapital og gjeld"
 
-#: itkufs/templates/reports/balance.html:74
+#: itkufs/templates/reports/balance.html:71
 msgid "Liabilities"
 msgstr "Gjeld"
 
-#: itkufs/templates/reports/balance.html:95
+#: itkufs/templates/reports/balance.html:92
 msgid "Total liabilities"
 msgstr "Total gjeld"
 
-#: itkufs/templates/reports/balance.html:102
+#: itkufs/templates/reports/balance.html:99
 msgid "Equities"
 msgstr "Egenkapital"
 
-#: itkufs/templates/reports/balance.html:123
+#: itkufs/templates/reports/balance.html:120
 msgid "Total equities (Net worth)"
 msgstr "Total egenkapital (nettoverdi)"
 
-#: itkufs/templates/reports/balance.html:130
+#: itkufs/templates/reports/balance.html:127
 msgid "Total liabilities and equities"
 msgstr "Total egenkapital og gjeld"
 
@@ -1462,23 +1467,23 @@ msgstr "Rapporter"
 msgid "Specify a date range to see incomes and expenses for that period."
 msgstr "Velg en periode for å se inntekter og utgifter for den perioden."
 
-#: itkufs/templates/reports/income.html:40
+#: itkufs/templates/reports/income.html:39
 msgid "Revenues and gains"
 msgstr "Inntekter og gevinster"
 
-#: itkufs/templates/reports/income.html:55
+#: itkufs/templates/reports/income.html:54
 msgid "Total revenues and gains"
 msgstr "Totale inntekter og gevinster"
 
-#: itkufs/templates/reports/income.html:64
+#: itkufs/templates/reports/income.html:63
 msgid "Expenses and losses"
 msgstr "Utgifter og tap"
 
-#: itkufs/templates/reports/income.html:79
+#: itkufs/templates/reports/income.html:78
 msgid "Total expenses and losses"
 msgstr "Totale utgifter og tap"
 
-#: itkufs/templates/reports/income.html:86
+#: itkufs/templates/reports/income.html:85
 msgid "Net income"
 msgstr "Nettoinntekt"
 

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -158,3 +158,42 @@ class ColumnForm(forms.ModelForm):
     class Meta:
         model = ListColumn
         fields = ("name", "width")
+
+
+class BalanceStatementForm(forms.Form):
+    date = forms.DateField(
+        label=_("Date"),
+        required=True,
+        error_messages={"required": _("Please enter a date")},
+    )
+    accounts = forms.ChoiceField(
+        label=_("Accounts"),
+        choices=[
+            ("active", _("Hide inactive accounts")),
+            ("all", _("Show all accounts")),
+        ],
+        initial="active",
+        widget=forms.Select,
+    )
+
+
+class IncomeStatementForm(forms.Form):
+    from_date = forms.DateField(
+        label=_("From date"),
+        required=True,
+        error_messages={"required": _("Please enter a date")},
+    )
+    to_date = forms.DateField(
+        label=_("To date"),
+        required=True,
+        error_messages={"required": _("Please enter a date")},
+    )
+    accounts = forms.ChoiceField(
+        label=_("Accounts"),
+        choices=[
+            ("active", _("Hide inactive accounts")),
+            ("all", _("Show all accounts")),
+        ],
+        initial="active",
+        widget=forms.Select,
+    )

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -163,17 +163,18 @@ class ColumnForm(forms.ModelForm):
 class BalanceStatementForm(forms.Form):
     date = forms.DateField(
         label=_("Date"),
-        required=True,
+        required=False,
         error_messages={"required": _("Please enter a date")},
     )
-    accounts = forms.ChoiceField(
-        label=_("Accounts"),
-        choices=[
-            ("active", _("Hide inactive accounts")),
-            ("all", _("Show all accounts")),
-        ],
-        initial="active",
-        widget=forms.Select,
+    hide_empty_active = forms.BooleanField(
+        label=_("Hide empty active accounts"),
+        initial=False,
+        required=False,
+    )
+    hide_empty_inactive = forms.BooleanField(
+        label=_("Hide empty inactive accounts"),
+        initial=True,
+        required=False,
     )
 
 
@@ -188,12 +189,13 @@ class IncomeStatementForm(forms.Form):
         required=True,
         error_messages={"required": _("Please enter a date")},
     )
-    accounts = forms.ChoiceField(
-        label=_("Accounts"),
-        choices=[
-            ("active", _("Hide inactive accounts")),
-            ("all", _("Show all accounts")),
-        ],
-        initial="active",
-        widget=forms.Select,
+    hide_empty_active = forms.BooleanField(
+        label=_("Hide empty active accounts"),
+        initial=False,
+        required=False,
+    )
+    hide_empty_inactive = forms.BooleanField(
+        label=_("Hide empty inactive accounts"),
+        initial=True,
+        required=False,
     )

--- a/itkufs/reports/forms.py
+++ b/itkufs/reports/forms.py
@@ -168,12 +168,10 @@ class BalanceStatementForm(forms.Form):
     )
     hide_empty_active = forms.BooleanField(
         label=_("Hide empty active accounts"),
-        initial=False,
         required=False,
     )
     hide_empty_inactive = forms.BooleanField(
         label=_("Hide empty inactive accounts"),
-        initial=True,
         required=False,
     )
 
@@ -191,11 +189,9 @@ class IncomeStatementForm(forms.Form):
     )
     hide_empty_active = forms.BooleanField(
         label=_("Hide empty active accounts"),
-        initial=False,
         required=False,
     )
     hide_empty_inactive = forms.BooleanField(
         label=_("Hide empty inactive accounts"),
-        initial=True,
         required=False,
     )

--- a/itkufs/reports/views.py
+++ b/itkufs/reports/views.py
@@ -247,18 +247,20 @@ def balance(request: HttpRequest, group: Group, is_admin=False):
     """Show balance sheet for the group"""
 
     if request.GET:
-        form = BalanceStatementForm(data=request.GET)
+        # Get data from user
+        data = request.GET
     else:
-        form = BalanceStatementForm(initial={"date": datetime.date.today()})
+        # Set default values
+        data = {"date": datetime.date.today(), "hide_empty_inactive": True}
+
+    form = BalanceStatementForm(data)
 
     if form.is_valid():
         date = form.cleaned_data["date"]
         hide_empty_active = form.cleaned_data["hide_empty_active"]
         hide_empty_inactive = form.cleaned_data["hide_empty_inactive"]
     else:
-        date = datetime.date.today()
-        hide_empty_active = form.fields["hide_empty_active"].initial
-        hide_empty_inactive = form.fields["hide_empty_inactive"].initial
+        raise ValueError("Invalid form data.")
 
     # Get account balances at the given date for relevant accounts
     balances = (
@@ -343,18 +345,18 @@ def balance(request: HttpRequest, group: Group, is_admin=False):
 def income(request: HttpRequest, group: Group, is_admin=False):
     """Show income statement for group"""
 
-    # Arbitrary date before the first possible transaction date
-    BEGINNING_OF_TIME = datetime.date(1929, 10, 1)
-
     if request.GET:
-        form = IncomeStatementForm(data=request.GET)
+        # Get data from user
+        data = request.GET
     else:
-        form = IncomeStatementForm(
-            initial={
-                "from_date": BEGINNING_OF_TIME,
-                "to_date": datetime.date.today(),
-            }
-        )
+        # Set default values
+        data = {
+            "from_date": datetime.date(1929, 10, 1),
+            "to_date": datetime.date.today(),
+            "hide_empty_inactive": True,
+        }
+
+    form = IncomeStatementForm(data)
 
     if form.is_valid():
         from_date = form.cleaned_data["from_date"]
@@ -362,10 +364,7 @@ def income(request: HttpRequest, group: Group, is_admin=False):
         hide_empty_active = form.cleaned_data["hide_empty_active"]
         hide_empty_inactive = form.cleaned_data["hide_empty_inactive"]
     else:
-        from_date = BEGINNING_OF_TIME
-        to_date = datetime.date.today()
-        hide_empty_active = form.fields["hide_empty_active"].initial
-        hide_empty_inactive = form.fields["hide_empty_inactive"].initial
+        raise ValueError("Invalid form data.")
 
     # Find the balance for each account at the start of the period
     starting_balances = (

--- a/itkufs/templates/reports/balance.html
+++ b/itkufs/templates/reports/balance.html
@@ -18,11 +18,25 @@
 {% block header %}
     {{ block.super }}
     &ndash; {% trans "Balance statement" %}
-    &ndash; {{ today }}
+    &ndash; {{ to_date|date:"Y-m-d" }}
 {% endblock %}
 
 
 {% block content %}
+
+<p>
+    {% trans "Select a date to see account balances at that date." %}
+</p>
+
+<form method="GET" action="#" class="plainform">
+
+{{ form.as_p }}
+
+<p>
+    <button type="submit">{% trans "Update" %}</button>
+</p>
+
+</form>
 
 <div class="float_left">
 <table class="tablelist">
@@ -33,7 +47,7 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
+                <a href="{{ account.url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -63,7 +77,7 @@
     <tr>
         <td>&nbsp;&nbsp;&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
+                <a href="{{ account.url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -71,10 +85,10 @@
         <td class="align_right">{{ account.normal_balance|floatformat:2 }}</td>
     </tr>
 {% endfor %}
-{% for name, balance in accounts.li|slice:"-2:" %}
+{% for account in accounts.li|slice:"-2:" %}
     <tr>
-        <td>&nbsp;&nbsp;&nbsp;&nbsp;{{ name  }}</td>
-		<td class="align_right">{{ balance }}</td>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;{{ account.name  }}</td>
+		<td class="align_right">{{ account.balance }}</td>
     </tr>
 {% endfor %}
     <tr>
@@ -91,7 +105,7 @@
     <tr>
         <td>&nbsp;&nbsp;&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
+                <a href="{{ account.url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}

--- a/itkufs/templates/reports/balance.html
+++ b/itkufs/templates/reports/balance.html
@@ -29,13 +29,10 @@
 </p>
 
 <form method="GET" action="#" class="plainform">
-
 {{ form.as_p }}
-
 <p>
     <button type="submit">{% trans "Update" %}</button>
 </p>
-
 </form>
 
 <div class="float_left">

--- a/itkufs/templates/reports/balance.html
+++ b/itkufs/templates/reports/balance.html
@@ -44,7 +44,7 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.url }}">{{ account.name }}</a>
+                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -74,7 +74,7 @@
     <tr>
         <td>&nbsp;&nbsp;&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.url }}">{{ account.name }}</a>
+                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -85,7 +85,7 @@
 {% for account in accounts.li|slice:"-2:" %}
     <tr>
         <td>&nbsp;&nbsp;&nbsp;&nbsp;{{ account.name  }}</td>
-		<td class="align_right">{{ account.balance }}</td>
+		<td class="align_right">{{ account.balance|floatformat:2 }}</td>
     </tr>
 {% endfor %}
     <tr>
@@ -102,7 +102,7 @@
     <tr>
         <td>&nbsp;&nbsp;&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.url }}">{{ account.name }}</a>
+                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}

--- a/itkufs/templates/reports/income.html
+++ b/itkufs/templates/reports/income.html
@@ -35,6 +35,8 @@
     <button type="submit">{% trans "Update" %}</button>
 </p>
 
+</form>
+
 <table class="tablelist float_left">
     <tr>
         <th colspan="2">{% trans "Revenues and gains" %}</th>

--- a/itkufs/templates/reports/income.html
+++ b/itkufs/templates/reports/income.html
@@ -17,13 +17,23 @@
 {% block header %}
     {{ block.super }}
     &ndash; {% trans "Income statement" %}
-    &ndash; {% trans "up to" %} {{ today }}
+    &ndash; {{ from_date|date:"Y-m-d" }}/{{ to_date|date:"Y-m-d" }}
 {% endblock %}
 
 
 {% block content %}
 
-{# <p>FIXME: Delimit income statement to time interval.</p> #}
+<p>
+    {% trans "Specify a date range to see incomes and expenses for that period." %}
+</p>
+
+<form method="GET" action="#" class="plainform">
+
+{{ form.as_p }}
+
+<p>
+    <button type="submit">{% trans "Update" %}</button>
+</p>
 
 <table class="tablelist float_left">
     <tr>
@@ -33,7 +43,7 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
+                <a href="{{ account.url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -57,7 +67,7 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
+                <a href="{{ account.url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
@@ -74,7 +84,7 @@
 
     <tr>
         <th>{% trans "Net income" %}</th>
-        <th class="align_right">{{ accounts.in_ex_diff|floatformat:2 }}</th>
+        <th class="align_right">{{ account_sums.in_ex_diff|floatformat:2 }}</th>
     </tr>
 </table>
 

--- a/itkufs/templates/reports/income.html
+++ b/itkufs/templates/reports/income.html
@@ -42,12 +42,12 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.url }}">{{ account.name }}</a>
+                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
         </td>
-        <td class="align_right">{{ account.normal_balance|floatformat:2 }}</td>
+        <td class="align_right">{{ account.balance_change|floatformat:2 }}</td>
     </tr>
 {% endfor %}
     <tr>
@@ -66,12 +66,12 @@
     <tr>
         <td>&nbsp;&nbsp;
             {% if is_admin %}
-                <a href="{{ account.url }}">{{ account.name }}</a>
+                <a href="{{ account.get_absolute_url }}">{{ account.name }}</a>
             {% else %}
                 {{ account.name }}
             {% endif %}
         </td>
-        <td class="align_right">{{ account.normal_balance|floatformat:2 }}</td>
+        <td class="align_right">{{ account.balance_change|floatformat:2 }}</td>
     </tr>
 {% endfor %}
     <tr>

--- a/itkufs/templates/reports/income.html
+++ b/itkufs/templates/reports/income.html
@@ -28,13 +28,10 @@
 </p>
 
 <form method="GET" action="#" class="plainform">
-
 {{ form.as_p }}
-
 <p>
     <button type="submit">{% trans "Update" %}</button>
 </p>
-
 </form>
 
 <table class="tablelist float_left">

--- a/itkufs/templates/reports/transaction_export.html
+++ b/itkufs/templates/reports/transaction_export.html
@@ -28,7 +28,7 @@
 
 <form method="GET" action="#" class="plainform">
 
-{{ form }}
+{{ form.as_p }}
 
 <p>
   <button type="submit">{% trans "Download" %}</button>


### PR DESCRIPTION
Adds the option to choose dates for both income statements and balance statements.
For balance statements this means seeing the actual balance on a given date, while for income statements it means seeing the change in balance between two dates.

Also does some minor refactoring and regenerates translation files (due to new strings added).